### PR TITLE
Improved exception messages

### DIFF
--- a/enumeratum-core/src/main/scala/enumeratum/Enum.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/Enum.scala
@@ -66,7 +66,8 @@ trait Enum[A <: EnumEntry] {
     * .entryName values.
     */
   def withName(name: String): A =
-    withNameOption(name) getOrElse (throw new NoSuchElementException(s"$name is not a member of Enum $this"))
+    withNameOption(name) getOrElse
+      (throw new NoSuchElementException(s"$name is not a member of Enum (${values.map(_.entryName).mkString(", ")})"))
 
   /**
    * Optionally returns an [[A]] for a given name.
@@ -81,7 +82,8 @@ trait Enum[A <: EnumEntry] {
     * .entryName values.
    */
   def withNameInsensitive(name: String): A =
-    withNameInsensitiveOption(name) getOrElse (throw new NoSuchElementException(s"$name is not a member of Enum $this"))
+    withNameInsensitiveOption(name) getOrElse
+      (throw new NoSuchElementException(s"$name is not a member of Enum (${values.map(_.entryName).mkString(", ")})"))
 
   /**
     * Optionally returns an [[A]] for a given name, disregarding case


### PR DESCRIPTION
Enum's mangled name used in previous version is not very useful, especially when used in conjunction with frameworks such as spray or akka-http where bubbled up exceptions are shown to end users as errors. Providing enum members seems as a better idea. Let me know what you think.