### PR TITLE
Change error message for Play JSON to be like Play

### DIFF
--- a/enumeratum-play-json/src/main/scala/enumeratum/EnumFormats.scala
+++ b/enumeratum-play-json/src/main/scala/enumeratum/EnumFormats.scala
@@ -19,10 +19,10 @@ object EnumFormats {
         val maybeBound = if (insensitive) enum.withNameInsensitiveOption(s) else enum.withNameOption(s)
         maybeBound match {
           case Some(obj) => JsSuccess(obj)
-          case None => JsError(s"Enumeration expected of type: '$enum', but it does not appear to contain the value: '$s'")
+          case None => JsError("error.expected.validenumvalue")
         }
       }
-      case _ => JsError("String value expected")
+      case _ => JsError("error.expected.enumstring")
     }
   }
 

--- a/enumeratum-play-json/src/test/scala/enumeratum/EnumFormatsSpec.scala
+++ b/enumeratum-play-json/src/test/scala/enumeratum/EnumFormatsSpec.scala
@@ -2,7 +2,7 @@ package enumeratum
 
 import org.scalatest.OptionValues._
 import org.scalatest.{ FunSpec, Matchers }
-import play.api.libs.json.{ JsNumber, JsString }
+import play.api.libs.json.{ JsNumber, JsResult, JsString }
 
 class EnumFormatsSpec extends FunSpec with Matchers {
 
@@ -15,7 +15,9 @@ class EnumFormatsSpec extends FunSpec with Matchers {
 
     it("should create a reads that fails with invalid values") {
       reads.reads(JsString("D")).isError should be(true)
+      errorMessages(reads.reads(JsString("D"))) should be(Seq("error.expected.validenumvalue"))
       reads.reads(JsNumber(2)).isError should be(true)
+      errorMessages(reads.reads(JsNumber(2))) should be(Seq("error.expected.enumstring"))
     }
   }
 
@@ -29,7 +31,9 @@ class EnumFormatsSpec extends FunSpec with Matchers {
 
     it("should create a reads that fails with invalid values") {
       reads.reads(JsString("D")).isError should be(true)
+      errorMessages(reads.reads(JsString("D"))) should be(Seq("error.expected.validenumvalue"))
       reads.reads(JsNumber(2)).isError should be(true)
+      errorMessages(reads.reads(JsNumber(2))) should be(Seq("error.expected.enumstring"))
     }
   }
 
@@ -58,4 +62,11 @@ class EnumFormatsSpec extends FunSpec with Matchers {
     }
   }
 
+  def errorMessages(jsResult: JsResult[_]): Seq[String] =
+    jsResult.fold(
+      _.collect {
+        case (path, errors) => errors.map(_.message).mkString
+      },
+      _ => Seq.empty
+    )
 }


### PR DESCRIPTION
In Play JSON, a small number of constant strings are used for validation errors. These can then be [localized](https://github.com/playframework/playframework/blob/9a06b9a0a6ea7d1299e61ea3c1f37a08b714297e/framework/src/play/src/main/resources/messages.default). It also enables non-Play code to use this message, combined with the path specifying the bad field's location, to generate useful messages.

This change modifies the Play JSON `Reads` for enums to use strings already [in use](https://github.com/playframework/playframework/blob/bf29d718c426d1d30d10553ad2e6b609bc1091fe/framework/src/play-json/src/main/scala/play/api/libs/json/Reads.scala#L752) in Play. Although on their own they are less informative than what's there now, they fit in better with Play and when combined with paths can be used to make more informative messages. (This is our use case. We're not using the play framework but expecting Play JSON behaviour. With current enumeratum behavior we have to prefix-match the error string to generate our errors, but match constant strings for other fields).

If you prefer I can make this an optional thing, like case-insensitivity, but I thought I'd propose this simpler change first.