### PR TITLE
README.md : fix example with sealed abstract class

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ to manually override the `def entryName: String` method.
 
 import enumeratum._
 
-sealed abstract class State(override def entryName: String) extends EnumEntry
+sealed abstract class State(override val entryName: String) extends EnumEntry
 
 object State extends Enum[State] {
 


### PR DESCRIPTION
Using `sealed abstract class State(override def entryName: String) extends EnumEntry`, as described in README.md, raises the following error : 

```
error: 'val' expected but 'def' found.
       sealed abstract class State(override def entryName: String) extends EnumEntry
                                            ^
```

Using `sealed abstract class State(override val entryName: String) extends EnumEntry` instead compiles.