### PR TITLE
Avoid boxing when calling withValue, withValueOpt on IntEnum, ShortEnum

### DIFF
--- a/enumeratum-core/compat/src/main/scala-2.11/enumeratum/values/IndexedEnumMap.scala
+++ b/enumeratum-core/compat/src/main/scala-2.11/enumeratum/values/IndexedEnumMap.scala
@@ -1,0 +1,73 @@
+package enumeratum.values
+
+/**
+ * An [[ValueEnum]] that has an optimized array access that does not uses
+ * boxing when accessing the methods [[ValueEnum.withValue()]] and [[ValueEnum.withValueOpt()]]
+ */
+sealed abstract class IndexedEnumMap[@specialized(Int, Short, Long) ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType]](values: Seq[EntryType]) {
+
+  private[this] val existingEntriesString = values.map(_.value).mkString(", ")
+  private[this] val (arrayValues, minValue) = {
+    val indices = values.map(v => toIndex(v.value))
+
+    val minValue = indices.min
+    val maxValue = indices.max
+
+    val retVal = Array.fill[Option[EntryType]](maxValue - minValue + 1)(None)
+
+    for (value <- values) {
+      retVal(toIndex(value.value) - minValue) = Some(value)
+    }
+
+    (retVal, minValue)
+  }
+
+  /**
+   * Tries to get an [[Int]] by the supplied value. The value corresponds to the .value
+   * of the case objects implementing [[Int]]
+   *
+   * Like [[Enumeration]]'s `withValue`, this method will throw if the value does not match any of the values'
+   * `.value` values.
+   */
+  final def withValue(i: ValueType): EntryType = {
+    val index = toIndex(i) - minValue
+    if (index >= arrayValues.length || index < 0) {
+      throw new NoSuchElementException(buildNotFoundMessage(i))
+    } else {
+      arrayValues(index).getOrElse(throw new NoSuchElementException(buildNotFoundMessage(i)))
+    }
+  }
+
+  /**
+   * Converts the given value to [[Int]]
+   *
+   * @param value The value to convert
+   * @return The converted value
+   */
+  @inline def toIndex(value: ValueType): Int
+
+  /**
+   * Optionally returns an [[Int]] for a given value.
+   */
+  final def withValueOpt(i: ValueType) = {
+    val index = toIndex(i) - minValue
+    if (index >= arrayValues.length || index < 0) None else arrayValues(index)
+  }
+
+  private final def buildNotFoundMessage(i: ValueType): String = {
+    s"$i is not a member of ValueEnum ($values)"
+  }
+
+}
+
+sealed class IntIndexedEnumMap[A <: ValueEnumEntry[Int]](values: Seq[A]) extends IndexedEnumMap[Int, A](values) {
+  final override def toIndex(value: Int): Int = value
+}
+
+sealed class ShortIndexedEnumMap[A <: ValueEnumEntry[Short]](values: Seq[A]) extends IndexedEnumMap[Short, A](values) {
+  final override def toIndex(value: Short): Int = value.toInt
+}
+
+sealed class LongIndexedEnumMap[A <: ValueEnumEntry[Long]](values: Seq[A]) extends IndexedEnumMap[Long, A](values) {
+  final override def toIndex(value: Long): Int = value.toInt
+}

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/Drinks.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/Drinks.scala
@@ -16,6 +16,7 @@ case object Drinks extends ShortEnum[Drinks] {
   case object Wine extends Drinks(value = -10, name = "wine")
 
   val values = findValues
+  val indexedEnumMap = new ShortIndexedEnumMap[Drinks](values)
 
 }
 

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/Drinks.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/Drinks.scala
@@ -13,6 +13,7 @@ case object Drinks extends ShortEnum[Drinks] {
   case object AppleJuice extends Drinks(value = 2, name = "aj")
   case object Cola extends Drinks(value = 3, name = "cola")
   case object Beer extends Drinks(value = 4, name = "beer")
+  case object Wine extends Drinks(value = -10, name = "wine")
 
   val values = findValues
 

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/IndexedEnumBoxingBench.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/IndexedEnumBoxingBench.scala
@@ -1,0 +1,43 @@
+package enumeratum.values
+
+import org.scalameter.Measurer.BoxingCount
+import org.scalameter.api._
+import org.scalameter.picklers.noPickler._
+
+class IndexedEnumBoxingBench extends Bench.Forked[Map[String, Long]] {
+
+  import Aggregator.Implicits._
+
+  private val useIndexed = Gen.enumeration("useIndexed")(false, true)
+
+  override def defaultConfig = Context(
+    exec.independentSamples -> 1,
+    exec.assumeDeterministicRun -> true,
+    exec.maxWarmupRuns -> 1,
+    exec.minWarmupRuns -> 1,
+    exec.benchRuns -> 1
+  )
+  override def aggregator: Aggregator[Map[String, Long]] = Aggregator.max
+  override def measurer = BoxingCount.all()
+
+  performance of "IndexEnum" in {
+
+    measure method "withValueOpt" in {
+      using(useIndexed) in { useIndexed =>
+        var i = 0
+        while (i < 100000) {
+          if (useIndexed) {
+            Drinks.indexedEnumMap.withValue(1)
+            LibraryItem.indexedEnumMap.withValue(1)
+          } else {
+            Drinks.withValue(1)
+            LibraryItem.withValue(1)
+          }
+
+          i += 1
+        }
+      }
+    }
+  }
+
+}

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/LibraryItem.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/LibraryItem.scala
@@ -21,6 +21,7 @@ case object LibraryItem extends IntEnum[LibraryItem] {
   case object VideoClip extends LibraryItem(value = -1, name = "video-clip")
 
   val values = findValues
+  val indexedEnumMap = new IntIndexedEnumMap[LibraryItem](values)
 
 }
 

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/LibraryItem.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/LibraryItem.scala
@@ -18,6 +18,7 @@ case object LibraryItem extends IntEnum[LibraryItem] {
   case object Book extends LibraryItem(value = 1, name = "book")
   case object Magazine extends LibraryItem(10, "magazine")
   case object CD extends LibraryItem(14, name = "cd")
+  case object VideoClip extends LibraryItem(value = -1, name = "video-clip")
 
   val values = findValues
 

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumSpec.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumSpec.scala
@@ -23,6 +23,7 @@ class ValueEnumSpec extends FunSpec with Matchers with ValueEnumHelpers {
   testEnum("IntEnum", LibraryItem)
   testEnum("ShortEnum", Drinks)
   testEnum("LongEnum", ContentType)
+
   testEnum("when using val members in the body", MovieGenre)
 
   describe("compilation failures") {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -56,7 +56,13 @@ object Enumeratum extends Build {
     .dependsOn(macros)
 
   lazy val coreJs = core.js
-  lazy val coreJvm = core.jvm
+  lazy val coreJvm = core.jvm.settings(
+    libraryDependencies += "com.storm-enroute" %% "scalameter" % "0.7" % Test,
+    resolvers += "Sonatype OSS Snapshots" at
+      "https://oss.sonatype.org/content/repositories/releases",
+    testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework"),
+    parallelExecution in Test := false
+  )
 
   lazy val coreJVMTests = Project(id = "coreJVMTests", base = file("enumeratum-core-jvm-tests"), settings = commonWithPublishSettings)
     .settings(


### PR DESCRIPTION
Hi,

First of all, I didn't managed to run the tests successfully on the master branch, I hope that it relates to Scala.js. 

I've added a trait called `IndexedEnum`, This trait implements `withValue`, `withValueOpt` using the apply method of the indexedValues, Since the values are indexed, This trait is specialized for short and int, so calling the methods `withValue`, `withValueOpt` wouldn't cause boxing.

~~There is one thing, I'm not sure how the macro `ValueEnumMacros.findIntValueEntriesImpl[A]` works, And what happens if there is a gap between Enum Values (e.g, first value is 5).~~

I'm not sure if you want to make `ValueEnum` specialized for int and short, So there won't be boxing when people pass the `ValueEnum` as `ValueEnum` (and not as the real type)

The `ValueEnumSpec` passed and validated the changes :+1: 
