### PR TITLE
Type-safe and readable contains checking

### DIFF
--- a/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
@@ -64,7 +64,7 @@ object EnumEntry {
   /**
    * Helper implicit for more readable checking.
    */
-  implicit class ComparableEnum[A <: EnumEntry](enum: A) {
+  implicit class ComparableEnum[A <: EnumEntry](val enum: A) extends AnyVal {
     /**
      * Checks if the current enum value is contained by the set of enum values in the parameter list.
      * @param firstEnum First enum of the list.

--- a/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
@@ -61,4 +61,17 @@ object EnumEntry {
     abstract override def entryName: String = super.entryName.toLowerCase
   }
 
+  /**
+   * Helper implicit for more readable checking.
+   */
+  implicit class ComparableEnum[A <: EnumEntry](enum: A) {
+    /**
+     * Checks if the current enum value is contained by the set of enum values in the parameter list.
+     * @param firstEnum First enum of the list.
+     * @param otherEnums Remaining enums.
+     * @return `true` if the current value is contained by the parameter list.
+     */
+    def in(firstEnum: A, otherEnums: A*) = (firstEnum +: otherEnums).contains(enum)
+  }
+
 }

--- a/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
@@ -250,7 +250,28 @@ class EnumSpec extends FunSpec with Matchers {
         case object Bar extends Foo
         case object Baz extends Foo
       }
-        """ shouldNot compile
+      """ shouldNot compile
+    }
+  }
+
+  describe("in") {
+    import DummyEnum._
+
+    it("should return true if enum value is contained by the parameter list") {
+      val enum: DummyEnum = Hello
+      enum.in(Hello, GoodBye) should be(true)
+    }
+
+    it("should return false if enum value is not contained by the parameter list") {
+      val enum: DummyEnum = Hi
+      enum.in(Hello, GoodBye) should be(false)
+    }
+
+    it("should fail to compile if either enum in the parameter list is not instance of the same enum type as the checked one") {
+      """
+        val enum: DummyEnum = DummyEnum.Hi
+        enum.in(DummyEnum.Hello, SnakeEnum.ShoutGoodBye)
+      """ shouldNot compile
     }
   }
 


### PR DESCRIPTION
In my practice I experienced that it is a usual need to check whether an enum is contained by a list of enums. 
One way is Seq(E1,E2,..).contains(E) but i think the following syntax is more readable, intuitive and type-checked:
E.in(E1,E2,...).

Please consider if this approach is right. Thanks!