### PR TITLE
Adds support for lower/uppercase transformations

### DIFF
--- a/enumeratum-circe/src/main/scala/enumeratum/Circe.scala
+++ b/enumeratum-circe/src/main/scala/enumeratum/Circe.scala
@@ -18,12 +18,40 @@ object Circe {
     final def apply(a: A): Json = stringEncoder.apply(a.entryName)
   }
 
+  def encoderLowercase[A <: EnumEntry](enum: Enum[A]): Encoder[A] = new Encoder[A] {
+    final def apply(a: A): Json = stringEncoder.apply(a.entryName.toLowerCase)
+  }
+
+  def encoderUppercase[A <: EnumEntry](enum: Enum[A]): Encoder[A] = new Encoder[A] {
+    final def apply(a: A): Json = stringEncoder.apply(a.entryName.toUpperCase)
+  }
+
   /**
    * Returns a Decoder for the given enum
    */
   def decoder[A <: EnumEntry](enum: Enum[A]): Decoder[A] = new Decoder[A] {
     final def apply(c: HCursor): Result[A] = stringDecoder.apply(c).flatMap { s =>
       val maybeMember = enum.withNameOption(s)
+      maybeMember match {
+        case Some(member) => Xor.right(member)
+        case _ => Xor.left(DecodingFailure(s"$s' is not a member of enum $enum", c.history))
+      }
+    }
+  }
+
+  def decoderLowercaseOnly[A <: EnumEntry](enum: Enum[A]): Decoder[A] = new Decoder[A] {
+    final def apply(c: HCursor): Result[A] = stringDecoder.apply(c).flatMap { s =>
+      val maybeMember = enum.withNameLowercaseOnlyOption(s)
+      maybeMember match {
+        case Some(member) => Xor.right(member)
+        case _ => Xor.left(DecodingFailure(s"$s' is not a member of enum $enum", c.history))
+      }
+    }
+  }
+
+  def decoderUppercaseOnly[A <: EnumEntry](enum: Enum[A]): Decoder[A] = new Decoder[A] {
+    final def apply(c: HCursor): Result[A] = stringDecoder.apply(c).flatMap { s =>
+      val maybeMember = enum.withNameUppercaseOnlyOption(s)
       maybeMember match {
         case Some(member) => Xor.right(member)
         case _ => Xor.left(DecodingFailure(s"$s' is not a member of enum $enum", c.history))

--- a/enumeratum-circe/src/test/scala/enumeratum/CirceSpec.scala
+++ b/enumeratum-circe/src/test/scala/enumeratum/CirceSpec.scala
@@ -20,6 +20,18 @@ class CirceSpec extends FunSpec with Matchers {
       }
     }
 
+    it("should work for lower case") {
+      ShirtSize.values.foreach { entry =>
+        entry.asJson(Circe.encoderLowercase(ShirtSize)) shouldBe Json.fromString(entry.entryName.toLowerCase)
+      }
+    }
+
+    it("should work for upper case") {
+      ShirtSize.values.foreach { entry =>
+        entry.asJson(Circe.encoderUppercase(ShirtSize)) shouldBe Json.fromString(entry.entryName.toUpperCase)
+      }
+    }
+
   }
 
   describe("from Json") {
@@ -30,9 +42,33 @@ class CirceSpec extends FunSpec with Matchers {
       }
     }
 
+    it("should parse to members when given proper JSON for lower case") {
+      ShirtSize.values.foreach { entry =>
+        Json.fromString(entry.entryName.toLowerCase).as[ShirtSize](Circe.decoderLowercaseOnly(ShirtSize)) shouldBe Xor.Right(entry)
+      }
+    }
+
+    it("should parse to members when given proper JSON for upper case") {
+      ShirtSize.values.foreach { entry =>
+        Json.fromString(entry.entryName.toUpperCase).as[ShirtSize](Circe.decoderUppercaseOnly(ShirtSize)) shouldBe Xor.Right(entry)
+      }
+    }
+
     it("should fail to parse random JSON to members") {
       Json.fromString("XXL").as[ShirtSize].isLeft shouldBe true
       Json.fromInt(Int.MaxValue).as[ShirtSize].isLeft shouldBe true
+    }
+
+    it("should fail to parse mixed but not upper case") {
+      Json.fromString("Small").as[ShirtSize](Circe.decoderUppercaseOnly(ShirtSize)).isLeft shouldBe true
+      Json.fromString("Medium").as[ShirtSize](Circe.decoderUppercaseOnly(ShirtSize)).isLeft shouldBe true
+      Json.fromString("Large").as[ShirtSize](Circe.decoderUppercaseOnly(ShirtSize)).isLeft shouldBe true
+    }
+
+    it("should fail to parse mixed but not lower case") {
+      Json.fromString("Small").as[ShirtSize](Circe.decoderLowercaseOnly(ShirtSize)).isLeft shouldBe true
+      Json.fromString("Medium").as[ShirtSize](Circe.decoderLowercaseOnly(ShirtSize)).isLeft shouldBe true
+      Json.fromString("Large").as[ShirtSize](Circe.decoderLowercaseOnly(ShirtSize)).isLeft shouldBe true
     }
 
   }

--- a/enumeratum-core/src/main/scala/enumeratum/Enum.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/Enum.scala
@@ -41,6 +41,11 @@ trait Enum[A <: EnumEntry] {
    * Map of [[A]] object names in lower case to [[A]]s for case-insensitive comparison
    */
   lazy final val lowerCaseNamesToValuesMap: Map[String, A] = values map (v => v.entryName.toLowerCase -> v) toMap
+
+  /**
+   * Map of [[A]] object names in upper case to [[A]]s for case-insensitive comparison
+   */
+  lazy final val upperCaseNameValuesToMap: Map[String, A] = values map (v => v.entryName.toUpperCase -> v) toMap
   /**
    * Map of [[A]] to their index in the values sequence.
    *
@@ -86,9 +91,41 @@ trait Enum[A <: EnumEntry] {
       (throw new NoSuchElementException(buildNotFoundMessage(name)))
 
   /**
+   * Tries to get an [[A]] by the supplied name. The name corresponds to the .name
+   * of the case objects implementing [[A]] transformed to upper case
+   *
+   * Like [[Enumeration]]'s `withName`, this method will throw if the name does not match any of the values'
+   * .entryName values.
+   */
+  def withNameUppercaseOnly(name: String): A =
+    withNameUppercaseOnlyOption(name) getOrElse
+      (throw new NoSuchElementException(buildNotFoundMessage(name)))
+
+  /**
+   * Tries to get an [[A]] by the supplied name. The name corresponds to the .name
+   * of the case objects implementing [[A]] transformed to lower case
+   *
+   * Like [[Enumeration]]'s `withName`, this method will throw if the name does not match any of the values'
+   * .entryName values.
+   */
+  def withNameLowercaseOnly(name: String): A =
+    withNameLowercaseOnlyOption(name) getOrElse
+      (throw new NoSuchElementException(buildNotFoundMessage(name)))
+
+  /**
    * Optionally returns an [[A]] for a given name, disregarding case
    */
   def withNameInsensitiveOption(name: String): Option[A] = lowerCaseNamesToValuesMap get name.toLowerCase
+
+  /**
+   * Optionally returns an [[A]] for a given name assuming the value is upper case
+   */
+  def withNameUppercaseOnlyOption(name: String): Option[A] = upperCaseNameValuesToMap get name
+
+  /**
+   * Optionally returns an [[A]] for a given name assuming the value is lower case
+   */
+  def withNameLowercaseOnlyOption(name: String): Option[A] = lowerCaseNamesToValuesMap get name
 
   /**
    * Returns the index number of the member passed in the values picked up by this enum

--- a/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
@@ -93,6 +93,93 @@ class EnumSpec extends FunSpec with Matchers {
 
     }
 
+    describe("#withNameUppercaseOnly") {
+      it("should return the proper object when passed the proper string, transforming to upper case first") {
+        DummyEnum.withNameUppercaseOnly("HELLO") should be(Hello)
+        DummyEnum.withNameUppercaseOnly("GOODBYE") should be(GoodBye)
+        DummyEnum.withNameUppercaseOnly("HI") should be(Hi)
+      }
+
+      it("should return None for not uppercase but case insensitive values") {
+        intercept[NoSuchElementException] {
+          DummyEnum.withNameUppercaseOnly("Hello")
+        }
+        intercept[NoSuchElementException] {
+          DummyEnum.withNameUppercaseOnly("GoodBye")
+        }
+        intercept[NoSuchElementException] {
+          DummyEnum.withNameUppercaseOnly("Hi")
+        }
+      }
+
+      it("should throw an error otherwise") {
+        intercept[NoSuchElementException] {
+          DummyEnum.withNameUppercaseOnly("bbeeeech")
+        }
+      }
+    }
+
+    describe("#withNameUppercaseOnlyOption") {
+      it("should return the proper object when passed the proper string, transforming to upper case first") {
+        DummyEnum.withNameUppercaseOnlyOption("HELLO").value should be(Hello)
+        DummyEnum.withNameUppercaseOnlyOption("GOODBYE").value should be(GoodBye)
+        DummyEnum.withNameUppercaseOnlyOption("HI").value should be(Hi)
+      }
+
+      it("should return None for not uppercase but case insensitive values") {
+        DummyEnum.withNameUppercaseOnlyOption("Hello") should be(None)
+        DummyEnum.withNameUppercaseOnlyOption("GoodBye") should be(None)
+        DummyEnum.withNameUppercaseOnlyOption("Hi") should be(None)
+      }
+
+      it("should return None otherwise") {
+        DummyEnum.withNameUppercaseOnlyOption("bbeeeech") should be(None)
+      }
+    }
+
+    describe("#withNameLowercaseOnly") {
+      it("should return the proper object when passed the proper string, transforming to lower case first") {
+        DummyEnum.withNameLowercaseOnly("hello") should be(Hello)
+        DummyEnum.withNameLowercaseOnly("goodbye") should be(GoodBye)
+        DummyEnum.withNameLowercaseOnly("hi") should be(Hi)
+      }
+
+      it("should return None for not uppercase but case insensitive values") {
+        intercept[NoSuchElementException] {
+          DummyEnum.withNameLowercaseOnly("Hello")
+        }
+        intercept[NoSuchElementException] {
+          DummyEnum.withNameLowercaseOnly("GoodBye")
+        }
+        intercept[NoSuchElementException] {
+          DummyEnum.withNameLowercaseOnly("Hi")
+        }
+      }
+
+      it("should throw an error otherwise") {
+        intercept[NoSuchElementException] {
+          DummyEnum.withNameLowercaseOnly("bbeeeech")
+        }
+      }
+    }
+
+    describe("#withNameLowercaseOnlyOption") {
+      it("should return the proper object when passed the proper string, transforming to lower case first") {
+        DummyEnum.withNameLowercaseOnlyOption("hello").value should be(Hello)
+        DummyEnum.withNameLowercaseOnlyOption("goodbye").value should be(GoodBye)
+        DummyEnum.withNameLowercaseOnlyOption("hi").value should be(Hi)
+      }
+
+      it("should return None for not uppercase but case insensitive values") {
+        DummyEnum.withNameLowercaseOnlyOption("Hello") should be(None)
+        DummyEnum.withNameLowercaseOnlyOption("GoodBye") should be(None)
+        DummyEnum.withNameLowercaseOnlyOption("Hi") should be(None)
+      }
+
+      it("should throw an error otherwise") {
+        DummyEnum.withNameLowercaseOnlyOption("bbeeeech") should be(None)
+      }
+    }
   }
 
   describe("when a sealed trait is wrapped in another object") {

--- a/enumeratum-play-json/src/main/scala/enumeratum/EnumFormats.scala
+++ b/enumeratum-play-json/src/main/scala/enumeratum/EnumFormats.scala
@@ -26,11 +26,47 @@ object EnumFormats {
     }
   }
 
+  def readsLowercaseOnly[A <: EnumEntry](enum: Enum[A]): Reads[A] = new Reads[A] {
+    def reads(json: JsValue): JsResult[A] = json match {
+      case JsString(s) =>
+        enum.withNameLowercaseOnlyOption(s) match {
+          case Some(obj) => JsSuccess(obj)
+          case None => JsError("error.expected.validenumvalue")
+        }
+      case _ => JsError("error.expected.enumstring")
+    }
+  }
+
+  def readsUppercaseOnly[A <: EnumEntry](enum: Enum[A]): Reads[A] = new Reads[A] {
+    def reads(json: JsValue): JsResult[A] = json match {
+      case JsString(s) =>
+        enum.withNameUppercaseOnlyOption(s) match {
+          case Some(obj) => JsSuccess(obj)
+          case None => JsError("error.expected.validenumvalue")
+        }
+      case _ => JsError("error.expected.enumstring")
+    }
+  }
+
   /**
    * Returns a Json writes for a given enum [[Enum]]
    */
   def writes[A <: EnumEntry](enum: Enum[A]): Writes[A] = new Writes[A] {
     def writes(v: A): JsValue = JsString(v.entryName)
+  }
+
+  /**
+   * Returns a Json writes for a given enum [[Enum]] and transforms it to lower case
+   */
+  def writesLowercaseOnly[A <: EnumEntry](enum: Enum[A]): Writes[A] = new Writes[A] {
+    def writes(v: A): JsValue = JsString(v.entryName.toLowerCase)
+  }
+
+  /**
+   * Returns a Json writes for a given enum [[Enum]] and transforms it to upper case
+   */
+  def writesUppercaseOnly[A <: EnumEntry](enum: Enum[A]): Writes[A] = new Writes[A] {
+    def writes(v: A): JsValue = JsString(v.entryName.toUpperCase)
   }
 
   /**
@@ -41,6 +77,24 @@ object EnumFormats {
    */
   def formats[A <: EnumEntry](enum: Enum[A], insensitive: Boolean = false): Format[A] = {
     Format(reads(enum, insensitive), writes(enum))
+  }
+
+  /**
+   * Returns a Json format for a given enum [[Enum]] for handling lower case transformations
+   *
+   * @param enum The enum
+   */
+  def formatsLowerCaseOnly[A <: EnumEntry](enum: Enum[A]): Format[A] = {
+    Format(readsLowercaseOnly(enum), writesLowercaseOnly(enum))
+  }
+
+  /**
+   * Returns a Json format for a given enum [[Enum]] for handling upper case transformations
+   *
+   * @param enum The enum
+   */
+  def formatsUppercaseOnly[A <: EnumEntry](enum: Enum[A]): Format[A] = {
+    Format(readsUppercaseOnly(enum), writesUppercaseOnly(enum))
   }
 
 }

--- a/enumeratum-play-json/src/main/scala/enumeratum/PlayLowercaseJsonEnum.scala
+++ b/enumeratum-play-json/src/main/scala/enumeratum/PlayLowercaseJsonEnum.scala
@@ -1,0 +1,7 @@
+package enumeratum
+
+import play.api.libs.json.Format
+
+trait PlayLowercaseJsonEnum[A <: EnumEntry] { self: Enum[A] =>
+  implicit val jsonFormat: Format[A] = EnumFormats.formatsLowerCaseOnly(this)
+}

--- a/enumeratum-play-json/src/main/scala/enumeratum/PlayUppercaseJsonEnum.scala
+++ b/enumeratum-play-json/src/main/scala/enumeratum/PlayUppercaseJsonEnum.scala
@@ -1,0 +1,7 @@
+package enumeratum
+
+import play.api.libs.json.Format
+
+trait PlayUppercaseJsonEnum[A <: EnumEntry] { self: Enum[A] =>
+  implicit val jsonFormat: Format[A] = EnumFormats.formatsUppercaseOnly(this)
+}

--- a/enumeratum-play-json/src/test/scala/enumeratum/EnumFormatsSpec.scala
+++ b/enumeratum-play-json/src/test/scala/enumeratum/EnumFormatsSpec.scala
@@ -37,10 +37,52 @@ class EnumFormatsSpec extends FunSpec with Matchers {
     }
   }
 
+  describe("reads lower case") {
+    val reads = EnumFormats.readsLowercaseOnly(Dummy)
+
+    it("should create a reads that works with valid values that are lower case") {
+      reads.reads(JsString("a")).asOpt.value should be(Dummy.A)
+    }
+
+    it("should create a reads that fails with invalid values") {
+      reads.reads(JsString("A")).isError should be(true)
+      errorMessages(reads.reads(JsString("A"))) should be(Seq("error.expected.validenumvalue"))
+    }
+  }
+
+  describe("reads upper case") {
+    val reads = EnumFormats.readsUppercaseOnly(Dummy)
+
+    it("should create a reads that works with valid values that are lower case") {
+      reads.reads(JsString("A")).asOpt.value should be(Dummy.A)
+    }
+
+    it("should create a reads that fails with invalid values") {
+      reads.reads(JsString("a")).isError should be(true)
+      errorMessages(reads.reads(JsString("a"))) should be(Seq("error.expected.validenumvalue"))
+    }
+  }
+
   describe("writes") {
     val writer = EnumFormats.writes(Dummy)
 
     it("should create a writes that writes enum values to JsString") {
+      writer.writes(Dummy.A) should be(JsString("A"))
+    }
+  }
+
+  describe("writes lower case") {
+    val writer = EnumFormats.writesLowercaseOnly(Dummy)
+
+    it("should create a writes that writes enum values to JsString as lower case") {
+      writer.writes(Dummy.A) should be(JsString("a"))
+    }
+  }
+
+  describe("writes upper case") {
+    val writer = EnumFormats.writesUppercaseOnly(Dummy)
+
+    it("should create a writes that writes enum values to JsString as upper case") {
       writer.writes(Dummy.A) should be(JsString("A"))
     }
   }

--- a/enumeratum-play/src/main/scala/enumeratum/Forms.scala
+++ b/enumeratum-play/src/main/scala/enumeratum/Forms.scala
@@ -22,6 +22,31 @@ object Forms {
   def enum[A <: EnumEntry](enum: Enum[A], insensitive: Boolean = false): Mapping[A] = PlayForms.of(format(enum, insensitive))
 
   /**
+   * Returns an [[Enum]] mapping for lower case
+   *
+   * For example:
+   * {{{
+   *   Form("status" -> maps(Status))
+   * }}}
+   *
+   * @param enum The enum
+   */
+
+  def enumLowerCaseOnly[A <: EnumEntry](enum: Enum[A]): Mapping[A] = PlayForms.of(formatLowercaseOnly(enum))
+
+  /**
+   * Returns an [[Enum]] mapping for upper case
+   *
+   * For example:
+   * {{{
+   *   Form("status" -> maps(Status))
+   * }}}
+   *
+   * @param enum The enum
+   */
+  def enumUppercaseOnly[A <: EnumEntry](enum: Enum[A]): Mapping[A] = PlayForms.of(formatUppercaseOnly(enum))
+
+  /**
    * Returns a Formatter for [[Enum]]
    *
    * @param enum The enum
@@ -38,6 +63,40 @@ object Forms {
       }
     }
     def unbind(key: String, value: A) = Map(key -> value.entryName)
+  }
+
+  /**
+   * Returns a Formatter for [[Enum]] that transforms to lower case
+   *
+   * @param enum The enum
+   */
+  private[enumeratum] def formatLowercaseOnly[A <: EnumEntry](enum: Enum[A]): Formatter[A] = new Formatter[A] {
+    def bind(key: String, data: Map[String, String]) = {
+      play.api.data.format.Formats.stringFormat.bind(key, data).right.flatMap { s =>
+        enum.withNameLowercaseOnlyOption(s) match {
+          case Some(obj) => Right(obj)
+          case None => Left(Seq(FormError(key, "error.enum", Nil)))
+        }
+      }
+    }
+    def unbind(key: String, value: A) = Map(key -> value.entryName.toLowerCase)
+  }
+
+  /**
+   * Returns a Formatter for [[Enum]] that transforms to upper case
+   *
+   * @param enum The enum
+   */
+  private[enumeratum] def formatUppercaseOnly[A <: EnumEntry](enum: Enum[A]): Formatter[A] = new Formatter[A] {
+    def bind(key: String, data: Map[String, String]) = {
+      play.api.data.format.Formats.stringFormat.bind(key, data).right.flatMap { s =>
+        enum.withNameUppercaseOnlyOption(s) match {
+          case Some(obj) => Right(obj)
+          case None => Left(Seq(FormError(key, "error.enum", Nil)))
+        }
+      }
+    }
+    def unbind(key: String, value: A) = Map(key -> value.entryName.toUpperCase)
   }
 
 }

--- a/enumeratum-play/src/main/scala/enumeratum/PlayLowercaseEnum.scala
+++ b/enumeratum-play/src/main/scala/enumeratum/PlayLowercaseEnum.scala
@@ -1,0 +1,21 @@
+package enumeratum
+
+/**
+ * An Enum that has a lot of the Play-related implicits built-in so you can avoid
+ * boilerplate.
+ *
+ * Note, the binders created here transform to lower case.
+ *
+ * Things included are:
+ *
+ *   - implicit JSON format
+ *   - implicit PathBindable (for binding from request path)
+ *   - implicit QueryStringBindable (for binding from query strings)
+ *   - formField for doing things like `Form("hello" -> MyEnum.formField)`
+ *
+ */
+trait PlayLowercaseEnum[A <: EnumEntry] extends Enum[A]
+  with PlayLowercaseJsonEnum[A]
+  with PlayLowercasePathBindableEnum[A]
+  with PlayLowercaseQueryBindableEnum[A]
+  with PlayLowercaseFormFieldEnum[A]

--- a/enumeratum-play/src/main/scala/enumeratum/PlayLowercaseFormFieldEnum.scala
+++ b/enumeratum-play/src/main/scala/enumeratum/PlayLowercaseFormFieldEnum.scala
@@ -1,0 +1,12 @@
+package enumeratum
+
+import play.api.data.Mapping
+
+trait PlayLowercaseFormFieldEnum[A <: EnumEntry] { self: Enum[A] =>
+
+  /**
+   * Form field for this enum
+   */
+  val formField: Mapping[A] = Forms.enumLowerCaseOnly(self)
+}
+

--- a/enumeratum-play/src/main/scala/enumeratum/PlayLowercasePathBindableEnum.scala
+++ b/enumeratum-play/src/main/scala/enumeratum/PlayLowercasePathBindableEnum.scala
@@ -1,0 +1,31 @@
+package enumeratum
+
+import play.api.mvc.PathBindable
+import play.api.routing.sird.PathBindableExtractor
+
+trait PlayLowercasePathBindableEnum[A <: EnumEntry] { self: Enum[A] =>
+
+  /**
+   * Implicit path binder for Play's default router
+   */
+  implicit val pathBindable: PathBindable[A] = UrlBinders.pathBinderLowercaseOnly(self)
+
+  /**
+   * Binder for [[play.api.routing.sird]] router
+   *
+   * Example:
+   *
+   * {{{
+   *  import play.api.routing.sird._
+   *  import play.api.routing._
+   *  import play.api.mvc._
+   *
+   *  Router.from {
+   *    case GET(p"/hello/${Greeting.fromPath(greeting)}") => Action {
+   *      Results.Ok(s"$greeting")
+   *    }
+   *  }
+   * }}}
+   */
+  lazy val fromPath = new PathBindableExtractor[A]
+}

--- a/enumeratum-play/src/main/scala/enumeratum/PlayLowercaseQueryBindableEnum.scala
+++ b/enumeratum-play/src/main/scala/enumeratum/PlayLowercaseQueryBindableEnum.scala
@@ -1,0 +1,7 @@
+package enumeratum
+
+import play.api.mvc.QueryStringBindable
+
+trait PlayLowercaseQueryBindableEnum[A <: EnumEntry] { self: Enum[A] =>
+  implicit val queryBindable: QueryStringBindable[A] = UrlBinders.queryBinderLowercaseOnly(self)
+}

--- a/enumeratum-play/src/main/scala/enumeratum/PlayUppercaseEnum.scala
+++ b/enumeratum-play/src/main/scala/enumeratum/PlayUppercaseEnum.scala
@@ -1,0 +1,21 @@
+package enumeratum
+
+/**
+ * An Enum that has a lot of the Play-related implicits built-in so you can avoid
+ * boilerplate.
+ *
+ * Note, the binders created here transform to upper case.
+ *
+ * Things included are:
+ *
+ *   - implicit JSON format
+ *   - implicit PathBindable (for binding from request path)
+ *   - implicit QueryStringBindable (for binding from query strings)
+ *   - formField for doing things like `Form("hello" -> MyEnum.formField)`
+ *
+ */
+trait PlayUppercaseEnum[A <: EnumEntry] extends Enum[A]
+  with PlayUppercaseJsonEnum[A]
+  with PlayUppercasePathBindableEnum[A]
+  with PlayUppercaseQueryBindableEnum[A]
+  with PlayUppercaseFormFieldEnum[A]

--- a/enumeratum-play/src/main/scala/enumeratum/PlayUppercaseFormFieldEnum.scala
+++ b/enumeratum-play/src/main/scala/enumeratum/PlayUppercaseFormFieldEnum.scala
@@ -1,0 +1,11 @@
+package enumeratum
+
+import play.api.data.Mapping
+
+trait PlayUppercaseFormFieldEnum[A <: EnumEntry] { self: Enum[A] =>
+
+  /**
+   * Form field for this enum
+   */
+  val formField: Mapping[A] = Forms.enumUppercaseOnly(self)
+}

--- a/enumeratum-play/src/main/scala/enumeratum/PlayUppercasePathBindableEnum.scala
+++ b/enumeratum-play/src/main/scala/enumeratum/PlayUppercasePathBindableEnum.scala
@@ -1,0 +1,31 @@
+package enumeratum
+
+import play.api.mvc.PathBindable
+import play.api.routing.sird.PathBindableExtractor
+
+trait PlayUppercasePathBindableEnum[A <: EnumEntry] { self: Enum[A] =>
+
+  /**
+   * Implicit path binder for Play's default router
+   */
+  implicit val pathBindable: PathBindable[A] = UrlBinders.pathBinderUppercaseOnly(self)
+
+  /**
+   * Binder for [[play.api.routing.sird]] router
+   *
+   * Example:
+   *
+   * {{{
+   *  import play.api.routing.sird._
+   *  import play.api.routing._
+   *  import play.api.mvc._
+   *
+   *  Router.from {
+   *    case GET(p"/hello/${Greeting.fromPath(greeting)}") => Action {
+   *      Results.Ok(s"$greeting")
+   *    }
+   *  }
+   * }}}
+   */
+  lazy val fromPath = new PathBindableExtractor[A]
+}

--- a/enumeratum-play/src/main/scala/enumeratum/PlayUppercaseQueryBindableEnum.scala
+++ b/enumeratum-play/src/main/scala/enumeratum/PlayUppercaseQueryBindableEnum.scala
@@ -1,0 +1,7 @@
+package enumeratum
+
+import play.api.mvc.QueryStringBindable
+
+trait PlayUppercaseQueryBindableEnum[A <: EnumEntry] { self: Enum[A] =>
+  implicit val queryBindable: QueryStringBindable[A] = UrlBinders.queryBinderLowercaseOnly(self)
+}

--- a/enumeratum-play/src/main/scala/enumeratum/UrlBinders.scala
+++ b/enumeratum-play/src/main/scala/enumeratum/UrlBinders.scala
@@ -26,6 +26,36 @@ object UrlBinders {
   }
 
   /**
+   * Builds a [[PathBindable]] A for a given Enum A that transforms to lower case
+   *
+   * @param enum The enum
+   */
+  def pathBinderLowercaseOnly[A <: EnumEntry](enum: Enum[A]): PathBindable[A] = new PathBindable[A] {
+    def unbind(key: String, value: A): String = value.entryName.toLowerCase
+    def bind(key: String, value: String): Either[String, A] = {
+      enum.withNameLowercaseOnlyOption(value) match {
+        case Some(v) => Right(v)
+        case _ => Left(s"Unknown value supplied for $enum '$value'")
+      }
+    }
+  }
+
+  /**
+   * Builds a [[PathBindable]] A for a given Enum A that transforms to upper case
+   *
+   * @param enum The enum
+   */
+  def pathBinderUppercaseOnly[A <: EnumEntry](enum: Enum[A]): PathBindable[A] = new PathBindable[A] {
+    def unbind(key: String, value: A): String = value.entryName.toUpperCase
+    def bind(key: String, value: String): Either[String, A] = {
+      enum.withNameUppercaseOnlyOption(value) match {
+        case Some(v) => Right(v)
+        case _ => Left(s"Unknown value supplied for $enum '$value'")
+      }
+    }
+  }
+
+  /**
    * Builds a [[QueryStringBindable]] A for a given Enum A
    *
    * @param enum The enum
@@ -40,6 +70,46 @@ object UrlBinders {
         params.get(key).flatMap(_.headOption).map { p =>
           val maybeBound = if (insensitive) enum.withNameInsensitiveOption(p) else enum.withNameOption(p)
           maybeBound match {
+            case Some(v) => Right(v)
+            case _ => Left(s"Cannot parse parameter $key as an Enum: $this")
+          }
+        }
+      }
+    }
+
+  /**
+   * Builds a [[QueryStringBindable]] A for a given Enum A that transforms to lower case
+   *
+   * @param enum The enum
+   */
+  def queryBinderLowercaseOnly[A <: EnumEntry](enum: Enum[A]): QueryStringBindable[A] =
+    new QueryStringBindable[A] {
+
+      def unbind(key: String, value: A): String = s"$key=${value.entryName.toLowerCase}"
+
+      def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, A]] = {
+        params.get(key).flatMap(_.headOption).map { p =>
+          enum.withNameLowercaseOnlyOption(p) match {
+            case Some(v) => Right(v)
+            case _ => Left(s"Cannot parse parameter $key as an Enum: $this")
+          }
+        }
+      }
+    }
+
+  /**
+   * Builds a [[QueryStringBindable]] A for a given Enum A that transforms to upper case
+   *
+   * @param enum The enum
+   */
+  def queryBinderUppercaseOnly[A <: EnumEntry](enum: Enum[A]): QueryStringBindable[A] =
+    new QueryStringBindable[A] {
+
+      def unbind(key: String, value: A): String = s"$key=${value.entryName.toUpperCase}"
+
+      def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, A]] = {
+        params.get(key).flatMap(_.headOption).map { p =>
+          enum.withNameUppercaseOnlyOption(p) match {
             case Some(v) => Right(v)
             case _ => Left(s"Cannot parse parameter $key as an Enum: $this")
           }

--- a/enumeratum-play/src/test/scala/enumeratum/FormSpec.scala
+++ b/enumeratum-play/src/test/scala/enumeratum/FormSpec.scala
@@ -51,6 +51,42 @@ class FormSpec extends FunSpec with Matchers {
 
   }
 
+  describe(".enum lower case") {
+
+    val subject = Form("hello" -> enumLowerCaseOnly(Dummy))
+
+    it("should bind proper strings into an Enum value disregarding case") {
+      val r1 = subject.bind(Map("hello" -> "a"))
+      val r2 = subject.bind(Map("hello" -> "b"))
+      r1.value.value shouldBe Dummy.A
+      r2.value.value shouldBe Dummy.B
+    }
+
+    it("should fail to bind random strings") {
+      val r = subject.bind(Map("hello" -> "A"))
+      r.value shouldBe None
+    }
+
+  }
+
+  describe(".enum upper case") {
+
+    val subject = Form("hello" -> enumUppercaseOnly(Dummy))
+
+    it("should bind proper strings into an Enum value disregarding case") {
+      val r1 = subject.bind(Map("hello" -> "A"))
+      val r2 = subject.bind(Map("hello" -> "B"))
+      r1.value.value shouldBe Dummy.A
+      r2.value.value shouldBe Dummy.B
+    }
+
+    it("should fail to bind random strings") {
+      val r = subject.bind(Map("hello" -> "a"))
+      r.value shouldBe None
+    }
+
+  }
+
   describe(".format") {
 
     val subject = format(Dummy)
@@ -72,6 +108,50 @@ class FormSpec extends FunSpec with Matchers {
       r shouldBe Map("hello" -> "A")
     }
 
+  }
+
+  describe(".format lower case") {
+
+    val subject = formatLowercaseOnly(Dummy)
+
+    it("should bind proper strings into an Enum value") {
+      val r1 = subject.bind("hello", Map("hello" -> "a"))
+      val r2 = subject.bind("hello", Map("hello" -> "b"))
+      r1 shouldBe Right(Dummy.A)
+      r2 shouldBe Right(Dummy.B)
+    }
+
+    it("should fail to bind random strings") {
+      val r = subject.bind("hello", Map("hello" -> "A"))
+      r should be('left)
+    }
+
+    it("should unbind ") {
+      val r = subject.unbind("hello", Dummy.A)
+      r shouldBe Map("hello" -> "a")
+    }
+  }
+
+  describe(".format upper case") {
+
+    val subject = formatUppercaseOnly(Dummy)
+
+    it("should bind proper strings into an Enum value") {
+      val r1 = subject.bind("hello", Map("hello" -> "A"))
+      val r2 = subject.bind("hello", Map("hello" -> "B"))
+      r1 shouldBe Right(Dummy.A)
+      r2 shouldBe Right(Dummy.B)
+    }
+
+    it("should fail to bind random strings") {
+      val r = subject.bind("hello", Map("hello" -> "a"))
+      r should be('left)
+    }
+
+    it("should unbind ") {
+      val r = subject.unbind("hello", Dummy.A)
+      r shouldBe Map("hello" -> "A")
+    }
   }
 
   describe(".format case insensitive") {

--- a/enumeratum-play/src/test/scala/enumeratum/UrlBindersSpec.scala
+++ b/enumeratum-play/src/test/scala/enumeratum/UrlBindersSpec.scala
@@ -51,6 +51,54 @@ class UrlBindersSpec extends FunSpec with Matchers {
 
   }
 
+  describe(".pathBinder lower case") {
+
+    val subject = pathBinderLowercaseOnly(Dummy)
+
+    it("should create an enumeration binder that can bind strings corresponding to enum strings") {
+      subject.bind("hello", "a").right.value shouldBe Dummy.A
+      subject.bind("hello", "b").right.value shouldBe Dummy.B
+    }
+
+    it("should create an enumeration binder that cannot bind strings not found in the enumeration") {
+      subject.bind("hello", "Z").isLeft shouldBe true
+    }
+
+    it("should create an enumeration binder that cannot bind strings that aren't lower case but are mixed case") {
+      subject.bind("hello", "A").isLeft shouldBe true
+    }
+
+    it("should create an enumeration binder that can unbind values") {
+      subject.unbind("hello", Dummy.A) shouldBe "a"
+      subject.unbind("hello", Dummy.B) shouldBe "b"
+    }
+
+  }
+
+  describe(".pathBinder upper case") {
+
+    val subject = pathBinderUppercaseOnly(Dummy)
+
+    it("should create an enumeration binder that can bind strings corresponding to enum strings") {
+      subject.bind("hello", "A").right.value shouldBe Dummy.A
+      subject.bind("hello", "B").right.value shouldBe Dummy.B
+    }
+
+    it("should create an enumeration binder that cannot bind strings not found in the enumeration") {
+      subject.bind("hello", "Z").isLeft shouldBe true
+    }
+
+    it("should create an enumeration binder that cannot bind strings that aren't upper case but are mixed case") {
+      subject.bind("hello", "a").isLeft shouldBe true
+    }
+
+    it("should create an enumeration binder that can unbind values") {
+      subject.unbind("hello", Dummy.A) shouldBe "A"
+      subject.unbind("hello", Dummy.B) shouldBe "B"
+    }
+
+  }
+
   describe(".queryBinder") {
 
     val subject = queryBinder(Dummy)
@@ -83,6 +131,54 @@ class UrlBindersSpec extends FunSpec with Matchers {
     it("should create an enumeration binder that cannot bind strings not found in the enumeration") {
       subject.bind("hello", Map("hello" -> Seq("Z"))).value should be('left)
       subject.bind("hello", Map("helloz" -> Seq("A"))) shouldBe None
+    }
+
+    it("should create an enumeration binder that can unbind values") {
+      subject.unbind("hello", Dummy.A) should be("hello=A")
+      subject.unbind("hello", Dummy.B) should be("hello=B")
+    }
+
+  }
+
+  describe(".queryBinder lower case") {
+
+    val subject = queryBinderLowercaseOnly(Dummy)
+
+    it("should create an enumeration binder that can bind strings corresponding to enum strings regardless of case") {
+      subject.bind("hello", Map("hello" -> Seq("a"))).value.right.value should be(Dummy.A)
+    }
+
+    it("should create an enumeration binder that cannot bind strings not found in the enumeration") {
+      subject.bind("hello", Map("hello" -> Seq("Z"))).value should be('left)
+      subject.bind("hello", Map("helloz" -> Seq("a"))) shouldBe None
+    }
+
+    it("should create an enumeration binder that cannot bind strings that aren't lower case but are mixed case") {
+      subject.bind("hello", Map("hello" -> Seq("A"))).value should be('left)
+    }
+
+    it("should create an enumeration binder that can unbind values") {
+      subject.unbind("hello", Dummy.A) should be("hello=a")
+      subject.unbind("hello", Dummy.B) should be("hello=b")
+    }
+
+  }
+
+  describe(".queryBinder upper case") {
+
+    val subject = queryBinderUppercaseOnly(Dummy)
+
+    it("should create an enumeration binder that can bind strings corresponding to enum strings regardless of case") {
+      subject.bind("hello", Map("hello" -> Seq("A"))).value.right.value should be(Dummy.A)
+    }
+
+    it("should create an enumeration binder that cannot bind strings not found in the enumeration") {
+      subject.bind("hello", Map("hello" -> Seq("Z"))).value should be('left)
+      subject.bind("hello", Map("helloz" -> Seq("A"))) shouldBe None
+    }
+
+    it("should create an enumeration binder that cannot bind strings that aren't upper case but are mixed case") {
+      subject.bind("hello", Map("hello" -> Seq("a"))).value should be('left)
     }
 
     it("should create an enumeration binder that can unbind values") {

--- a/enumeratum-reactivemongo-bson/src/main/scala/enumeratum/EnumHandler.scala
+++ b/enumeratum-reactivemongo-bson/src/main/scala/enumeratum/EnumHandler.scala
@@ -29,10 +29,54 @@ object EnumHandler {
     }
 
   /**
+   * Returns a BSONReader for a given enum [[Enum]] transformed to lower case
+   *
+   * @param enum The enum
+   */
+  def readerLowercaseOnly[A <: EnumEntry](enum: Enum[A]): BSONReader[BSONValue, A] =
+    new BSONReader[BSONValue, A] {
+      override def read(bson: BSONValue): A = {
+        bson match {
+          case BSONString(s) => enum.withNameLowercaseOnly(s)
+          case _ => throw new RuntimeException("String value expected")
+        }
+      }
+    }
+
+  /**
+   * Returns a BSONReader for a given enum [[Enum]] transformed to upper case
+   *
+   * @param enum The enum
+   */
+  def readerUppercaseOnly[A <: EnumEntry](enum: Enum[A]): BSONReader[BSONValue, A] =
+    new BSONReader[BSONValue, A] {
+      override def read(bson: BSONValue): A = {
+        bson match {
+          case BSONString(s) => enum.withNameUppercaseOnly(s)
+          case _ => throw new RuntimeException("String value expected")
+        }
+      }
+    }
+
+  /**
    * Returns a BSONWriter for a given enum [[Enum]]
    */
   def writer[A <: EnumEntry](enum: Enum[A]): BSONWriter[A, BSONValue] = new BSONWriter[A, BSONValue] {
     override def write(t: A): BSONValue = BSONString(t.entryName)
+  }
+
+  /**
+   * Returns a BSONWriter for a given enum [[Enum]], outputting the value as lower case
+   */
+  def writerLowercase[A <: EnumEntry](enum: Enum[A]): BSONWriter[A, BSONValue] = new BSONWriter[A, BSONValue] {
+    override def write(t: A): BSONValue = BSONString(t.entryName.toLowerCase)
+  }
+
+  /**
+   * Returns a BSONWriter for a given enum [[Enum]], outputting the value as upper case
+   */
+  def writerUppercase[A <: EnumEntry](enum: Enum[A]): BSONWriter[A, BSONValue] = new BSONWriter[A, BSONValue] {
+    override def write(t: A): BSONValue = BSONString(t.entryName.toUpperCase)
   }
 
   /**
@@ -45,6 +89,36 @@ object EnumHandler {
     new BSONHandler[BSONValue, A] {
       val concreteReader = reader(enum, insensitive)
       val concreteWriter = writer(enum)
+
+      override def read(bson: BSONValue): A = concreteReader.read(bson)
+
+      override def write(t: A): BSONValue = concreteWriter.write(t)
+    }
+
+  /**
+   * Returns a BSONHandler for a given enum [[Enum]], handling a lower case transformation
+   *
+   * @param enum The enum
+   */
+  def handlerLowercaseOnly[A <: EnumEntry](enum: Enum[A]): BSONHandler[BSONValue, A] =
+    new BSONHandler[BSONValue, A] {
+      val concreteReader = readerLowercaseOnly(enum)
+      val concreteWriter = writerLowercase(enum)
+
+      override def read(bson: BSONValue): A = concreteReader.read(bson)
+
+      override def write(t: A): BSONValue = concreteWriter.write(t)
+    }
+
+  /**
+   * Returns a BSONHandler for a given enum [[Enum]], handling an upper case transformation
+   *
+   * @param enum The enum
+   */
+  def handlerUppercaseOnly[A <: EnumEntry](enum: Enum[A]): BSONHandler[BSONValue, A] =
+    new BSONHandler[BSONValue, A] {
+      val concreteReader = readerUppercaseOnly(enum)
+      val concreteWriter = writerUppercase(enum)
 
       override def read(bson: BSONValue): A = concreteReader.read(bson)
 

--- a/enumeratum-reactivemongo-bson/src/test/scala/enumeratum/EnumBsonHandlerSpec.scala
+++ b/enumeratum-reactivemongo-bson/src/test/scala/enumeratum/EnumBsonHandlerSpec.scala
@@ -38,11 +38,43 @@ class EnumBsonHandlerSpec extends FunSpec with Matchers {
     }
   }
 
+  describe("reader lower case") {
+    val reader = EnumHandler.readerLowercaseOnly(Dummy)
+
+    it("should create a reader that works with valid values that are lower case") {
+      reader.readOpt(BSONString("a")).value should be(Dummy.A)
+    }
+  }
+
+  describe("reader upper case") {
+    val reader = EnumHandler.readerUppercaseOnly(Dummy)
+
+    it("should create a reader that works with valid values that are upper case") {
+      reader.readOpt(BSONString("A")).value should be(Dummy.A)
+    }
+  }
+
   describe("writer") {
     val writer = EnumHandler.writer(Dummy)
 
     it("should create a writer that writes enum values to BSONString") {
       writer.write(Dummy.A) should be(BSONString("A"))
+    }
+  }
+
+  describe("writer upper case") {
+    val writer = EnumHandler.writerUppercase(Dummy)
+
+    it("should create a writer that writes enum values to BSONString as lower case") {
+      writer.write(Dummy.A) should be(BSONString("A"))
+    }
+  }
+
+  describe("writer lower case") {
+    val writer = EnumHandler.writerLowercase(Dummy)
+
+    it("should create a writer that writes enum values to BSONString as lower case") {
+      writer.write(Dummy.A) should be(BSONString("a"))
     }
   }
 

--- a/enumeratum-upickle/src/main/scala/enumeratum/UPickler.scala
+++ b/enumeratum-upickle/src/main/scala/enumeratum/UPickler.scala
@@ -21,6 +21,32 @@ object UPickler {
   }
 
   /**
+   * Returns a UPickle [[Reader]] for a given [[Enum]]
+   *
+   * @param enum the enum you wish to make a Reader for transformed to lower case
+   */
+  def readerLowercaseLower[A <: EnumEntry](enum: Enum[A]): Reader[A] = Reader[A] {
+    val stringReader = implicitly[Reader[String]]
+    val pfMaybeMemberToMember: PartialFunction[Option[A], A] = {
+      case Some(a) => a
+    }
+    stringReader.read.andThen(enum.withNameLowercaseOnlyOption).andThenPartial(pfMaybeMemberToMember)
+  }
+
+  /**
+   * Returns a UPickle [[Reader]] for a given [[Enum]]
+   *
+   * @param enum the enum you wish to make a Reader for transformed to upper case
+   */
+  def readerUppercaseOnly[A <: EnumEntry](enum: Enum[A]): Reader[A] = Reader[A] {
+    val stringReader = implicitly[Reader[String]]
+    val pfMaybeMemberToMember: PartialFunction[Option[A], A] = {
+      case Some(a) => a
+    }
+    stringReader.read.andThen(enum.withNameUppercaseOnlyOption).andThenPartial(pfMaybeMemberToMember)
+  }
+
+  /**
    * Returns a [[Writer]] for a given [[Enum]]
    *
    * @param enum [[Enum]] to make a [[Writer]] for
@@ -29,6 +55,30 @@ object UPickler {
     val stringWriter = implicitly[Writer[String]]
     Writer[A] {
       case member => stringWriter.write(member.entryName)
+    }
+  }
+
+  /**
+   * Returns a [[Writer]] for a given [[Enum]], outputted as lower case
+   *
+   * @param enum [[Enum]] to make a [[Writer]] for
+   */
+  def writerLowercaseOnly[A <: EnumEntry](enum: Enum[A]): Writer[A] = {
+    val stringWriter = implicitly[Writer[String]]
+    Writer[A] {
+      case member => stringWriter.write(member.entryName.toLowerCase)
+    }
+  }
+
+  /**
+   * Returns a [[Writer]] for a given [[Enum]], outputted as upper case
+   *
+   * @param enum [[Enum]] to make a [[Writer]] for
+   */
+  def writerUppercaseOnly[A <: EnumEntry](enum: Enum[A]): Writer[A] = {
+    val stringWriter = implicitly[Writer[String]]
+    Writer[A] {
+      case member => stringWriter.write(member.entryName.toUpperCase)
     }
   }
 

--- a/enumeratum-upickle/src/test/scala/enumeratum/UPickleSpec.scala
+++ b/enumeratum-upickle/src/test/scala/enumeratum/UPickleSpec.scala
@@ -44,9 +44,57 @@ class UPickleSpec extends FunSpec with Matchers {
 
   }
 
+  describe("lower case reader") {
+    val reader = UPickler.readerLowercaseLower(Dummy)
+
+    it("should work with strings, lower case") {
+      reader.read(Js.Str("a")) shouldBe A
+    }
+
+    it("should work with invalid values") {
+      intercept[Exception](reader.read(Js.Str("D")))
+      intercept[Exception](reader.read(Js.Num(5)))
+    }
+
+  }
+
+  describe("upper case reader") {
+    val reader = UPickler.readerUppercaseOnly(Dummy)
+
+    it("should work with strings, upper case") {
+      reader.read(Js.Str("A")) shouldBe A
+    }
+
+    it("should work with invalid values") {
+      intercept[Exception](reader.read(Js.Str("D")))
+      intercept[Exception](reader.read(Js.Num(5)))
+    }
+
+  }
+
   describe("Writer") {
 
     val writer = UPickler.writer(Dummy)
+
+    it("should write enum values to JsString") {
+      writer.write(A) shouldBe Js.Str("A")
+    }
+
+  }
+
+  describe("Writer lowercase") {
+
+    val writer = UPickler.writerLowercaseOnly(Dummy)
+
+    it("should write enum values to JsString") {
+      writer.write(A) shouldBe Js.Str("a")
+    }
+
+  }
+
+  describe("Writer uppercase") {
+
+    val writer = UPickler.writerUppercaseOnly(Dummy)
 
     it("should write enum values to JsString") {
       writer.write(A) shouldBe Js.Str("A")


### PR DESCRIPTION
This pull request adds support for lower/upper case transformations. Unlike case sensitive, these transformations will **only** support lower or upper case. Futhermore, they also alter any decoders (or writers/unbind depending on the framework that is supporting them).

This was done because in my personal use case, this logic is defined all the time. As an example we have an ENUM that is represented in a database with uppercase enum values, however the REST interface (which is implemented in play) only has lowercase names (which means we have to handle bind and unbind  transforming the value, instead of just returning the original value). Same deal with Json formatters and such