### PR TITLE
Make format/s non private

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,34 @@ object GreetingForm {
 }
 ```
 
+Another alternative (if your `Enum` cant extend `PlayEnum` or `PlayFormFieldEnum`) is to create an implicit `Format`
+and bring it into scope using Play's `of`, i.e.
+
+```scala
+import play.api.data.Form
+import play.api.data.Forms._
+
+object Formats {
+  implicit val greetingFormat = enumeratum.Forms.format(Greeting)
+}
+
+object GreetingForm {
+  import Formats._
+  
+  val form = Form(
+      mapping(
+        "name" -> nonEmptyText,
+        "greeting" -> of[Greeting]
+      )(Data.apply)(Data.unapply)
+    )
+  
+    case class Data(
+      name: String,
+      greeting: Greeting)
+
+}
+```
+
 ## Play JSON
 
 The `enumeratum-play-json` project is published separately and gives you access to Play's auto-generated boilerplate

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ object GreetingForm {
 }
 ```
 
-Another alternative (if for example your `Enum` cant extend `PlayEnum` or `PlayFormFieldEnum`) is to create an implicit `Format`
+Another alternative (if for example your `Enum` can't extend `PlayEnum` or `PlayFormFieldEnum`) is to create an implicit `Format`
 and bring it into scope using Play's `of`, i.e.
 
 ```scala

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ object GreetingForm {
 }
 ```
 
-Another alternative (if your `Enum` cant extend `PlayEnum` or `PlayFormFieldEnum`) is to create an implicit `Format`
+Another alternative (if for example your `Enum` cant extend `PlayEnum` or `PlayFormFieldEnum`) is to create an implicit `Format`
 and bring it into scope using Play's `of`, i.e.
 
 ```scala

--- a/enumeratum-play/src/main/scala/enumeratum/Forms.scala
+++ b/enumeratum-play/src/main/scala/enumeratum/Forms.scala
@@ -52,7 +52,7 @@ object Forms {
    * @param enum The enum
    * @param insensitive bind in a case-insensitive way, defaults to false
    */
-  private[enumeratum] def format[A <: EnumEntry](enum: Enum[A], insensitive: Boolean = false): Formatter[A] = new Formatter[A] {
+  def format[A <: EnumEntry](enum: Enum[A], insensitive: Boolean = false): Formatter[A] = new Formatter[A] {
     def bind(key: String, data: Map[String, String]) = {
       play.api.data.format.Formats.stringFormat.bind(key, data).right.flatMap { s =>
         val maybeBound = if (insensitive) enum.withNameInsensitiveOption(s) else enum.withNameOption(s)
@@ -70,7 +70,7 @@ object Forms {
    *
    * @param enum The enum
    */
-  private[enumeratum] def formatLowercaseOnly[A <: EnumEntry](enum: Enum[A]): Formatter[A] = new Formatter[A] {
+  def formatLowercaseOnly[A <: EnumEntry](enum: Enum[A]): Formatter[A] = new Formatter[A] {
     def bind(key: String, data: Map[String, String]) = {
       play.api.data.format.Formats.stringFormat.bind(key, data).right.flatMap { s =>
         enum.withNameLowercaseOnlyOption(s) match {
@@ -87,7 +87,7 @@ object Forms {
    *
    * @param enum The enum
    */
-  private[enumeratum] def formatUppercaseOnly[A <: EnumEntry](enum: Enum[A]): Formatter[A] = new Formatter[A] {
+  def formatUppercaseOnly[A <: EnumEntry](enum: Enum[A]): Formatter[A] = new Formatter[A] {
     def bind(key: String, data: Map[String, String]) = {
       play.api.data.format.Formats.stringFormat.bind(key, data).right.flatMap { s =>
         enum.withNameUppercaseOnlyOption(s) match {


### PR DESCRIPTION
This makes the various `format` methods non private. The reasoning is that, if you are unable to make your enums extend `PlayEnum` or its variants, the only way to create a mapping using an enum is to make a reference to it with the `enum` method, i.e.

```scala
val myEnumMapping = enumeratum.Forms.enum(MyEnum)
```

Unfortunately the only way you can use this mapping is by reference to a variable, not its type

```scala
Form(
    mapping(
        "field" -> myEnumMapping
    )
)
```

This is because play doesn't have any way to bring an implicit `Mapping` into scope, only an implicit `Formatter`. Making the format non privates means that you can do this

```scala
object Formats {
    implicit val myEnumFormat = enumeratum.Forms.format(MyEnum)
}
```

And then you can use plays `of` to summon an implicit `Format` from scope

```scala
import Formats._
Form(
    mapping(
        "field" -> of[MyEnum]
    )
)
```