### PR TITLE
Infer Enum[A] from A <: EnumEntry

### DIFF
--- a/enumeratum-core/src/main/scala/enumeratum/Enum.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/Enum.scala
@@ -2,6 +2,7 @@ package enumeratum
 
 import scala.language.experimental.macros
 import scala.language.postfixOps
+import ContextUtils.Context
 
 /**
  * All the cool kids have their own Enumeration implementation, most of which try to
@@ -149,4 +150,19 @@ trait Enum[A <: EnumEntry] {
 
   private lazy val existingEntriesString = values.map(_.entryName).mkString(", ")
 
+}
+
+object Enum {
+  implicit def materializeEnum[A <: EnumEntry]: Enum[A] = macro EnumMacrosAux.materializeEnumImpl[A]
+}
+
+object EnumMacrosAux {
+  /**
+   * Given an A <: EnumEntry, provide Enum[A]
+   */
+  def materializeEnumImpl[A <: EnumEntry: c.WeakTypeTag](c: Context) = {
+    import c.universe._
+    val symbol = weakTypeOf[A].typeSymbol
+    c.Expr[Enum[A]](Ident(symbol.companionSymbol))
+  }
 }

--- a/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
@@ -362,4 +362,14 @@ class EnumSpec extends FunSpec with Matchers {
     }
   }
 
+  describe("materializeEnum") {
+    import DummyEnum._
+
+    it("should return the proper Enum object") {
+      def findEnum[A <: EnumEntry: Enum](v: A) = implicitly[Enum[A]]
+
+      val hello: DummyEnum = Hello
+      findEnum(hello) shouldEqual DummyEnum
+    }
+  }
 }

--- a/macros/src/main/scala/enumeratum/EnumMacros.scala
+++ b/macros/src/main/scala/enumeratum/EnumMacros.scala
@@ -69,7 +69,9 @@ object EnumMacros {
             false
         }
       }
-    } catch { case NonFatal(e) => c.abort(c.enclosingPosition, s"Unexpected error: ${e.getMessage}") }
+    } catch {
+      case NonFatal(e) => c.abort(c.enclosingPosition, s"Unexpected error: ${e.getMessage}")
+    }
     if (!enclosingBodySubClassTrees.forall(x => x.symbol.isModule))
       c.abort(c.enclosingPosition, "All subclasses must be objects.")
     else enclosingBodySubClassTrees


### PR DESCRIPTION
Added a macro to infer automatically the Enum object of an EnumEntry.

This can be used to simplify mappings, serialization, etc.. For example, we can now do:

* An automatic Play JSON Formats:
```
implicit def enumFormat[A <: EnumEntry : Enum]: Format[A] = EnumFormats.formats(implicitly[Enum[A]])
```

* An automatic Slick mapper:

```
  implicit def enumMapper[A <: EnumEntry : Enum : ClassTag] = MappedColumnType.base[A, String](
    sn => sn.entryName,
    str => implicitly[Enum[A]].withName(str)
  )
```

* An io.underscore Validator:

```
  implicit def enumValidator2stringValidator[A <: EnumEntry : Enum](enumValidator: Validator[A]): Validator[String] =
    Validator[String] { in => implicitly[Enum[A]].withNameOption(in) map enumValidator getOrElse fail("Value is required") }
```

Etc...
