### PR TITLE
Refactor companion object finding

### DIFF
--- a/enumeratum-core/compat/src/main/scala-2.11/enumeratum/values/ValueEnum.scala
+++ b/enumeratum-core/compat/src/main/scala-2.11/enumeratum/values/ValueEnum.scala
@@ -1,6 +1,6 @@
 package enumeratum.values
 
-import enumeratum.ValueEnumMacros
+import enumeratum.{ EnumMacros, ValueEnumMacros }
 
 import scala.language.experimental.macros
 
@@ -51,6 +51,14 @@ sealed trait ValueEnum[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueTyp
  * and macro invocations cannot provide implementations for a super class's abstract method
  */
 
+object IntEnum {
+
+  /**
+   * Materializes an IntEnum for a given IntEnumEntry
+   */
+  implicit def materialiseIntValueEnum[EntryType <: IntEnumEntry]: IntEnum[EntryType] = macro EnumMacros.materializeEnumImpl[EntryType]
+
+}
 /**
  * Value enum with [[IntEnumEntry]] entries
  */
@@ -66,6 +74,15 @@ trait IntEnum[A <: IntEnumEntry] extends ValueEnum[Int, A] {
 
 }
 
+object LongEnum {
+
+  /**
+   * Materializes a LongEnum for an scope LongEnumEntry
+   */
+  implicit def materialiseLongValueEnum[EntryType <: LongEnumEntry]: LongEnum[EntryType] = macro EnumMacros.materializeEnumImpl[EntryType]
+
+}
+
 /**
  * Value enum with [[LongEnumEntry]] entries
  */
@@ -78,6 +95,15 @@ trait LongEnum[A <: LongEnumEntry] extends ValueEnum[Long, A] {
    * if you aren't using this method...why are you even bothering with this lib?
    */
   final protected def findValues: IndexedSeq[A] = macro ValueEnumMacros.findLongValueEntriesImpl[A]
+}
+
+object ShortEnum {
+
+  /**
+   * Materializes a ShortEnum for an inscope ShortEnumEntry
+   */
+  implicit def materialiseShortValueEnum[EntryType <: ShortEnumEntry]: ShortEnum[EntryType] = macro EnumMacros.materializeEnumImpl[EntryType]
+
 }
 
 /**

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumSpec.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumSpec.scala
@@ -25,6 +25,25 @@ class ValueEnumSpec extends FunSpec with Matchers with ValueEnumHelpers {
   testEnum("LongEnum", ContentType)
   testEnum("when using val members in the body", MovieGenre)
 
+  describe("finding companion object") {
+
+    it("should work for IntEnums") {
+      def findCompanion[EntryType <: IntEnumEntry: IntEnum] = implicitly[IntEnum[EntryType]]
+      findCompanion[LibraryItem].values should contain(LibraryItem.Magazine)
+    }
+
+    it("should work for ShortEnum") {
+      def findCompanion[EntryType <: ShortEnumEntry: ShortEnum] = implicitly[ShortEnum[EntryType]]
+      findCompanion[Drinks].values should contain(Drinks.Cola)
+    }
+
+    it("should work for LongEnum") {
+      def findCompanion[EntryType <: LongEnumEntry: LongEnum] = implicitly[LongEnum[EntryType]]
+      findCompanion[ContentType].values should contain(ContentType.Audio)
+    }
+
+  }
+
   describe("compilation failures") {
 
     describe("problematic values") {

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumSpec.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumSpec.scala
@@ -28,18 +28,24 @@ class ValueEnumSpec extends FunSpec with Matchers with ValueEnumHelpers {
   describe("finding companion object") {
 
     it("should work for IntEnums") {
-      def findCompanion[EntryType <: IntEnumEntry: IntEnum] = implicitly[IntEnum[EntryType]]
-      findCompanion[LibraryItem].values should contain(LibraryItem.Magazine)
+      def findCompanion[EntryType <: IntEnumEntry: IntEnum](entry: EntryType) = implicitly[IntEnum[EntryType]]
+      val companion = findCompanion(LibraryItem.Magazine: LibraryItem)
+      companion shouldBe LibraryItem
+      companion.values should contain(LibraryItem.Magazine)
     }
 
     it("should work for ShortEnum") {
-      def findCompanion[EntryType <: ShortEnumEntry: ShortEnum] = implicitly[ShortEnum[EntryType]]
-      findCompanion[Drinks].values should contain(Drinks.Cola)
+      def findCompanion[EntryType <: ShortEnumEntry: ShortEnum](entry: EntryType) = implicitly[ShortEnum[EntryType]]
+      val companion = findCompanion(Drinks.Beer: Drinks)
+      companion shouldBe Drinks
+      companion.values should contain(Drinks.Cola)
     }
 
     it("should work for LongEnum") {
-      def findCompanion[EntryType <: LongEnumEntry: LongEnum] = implicitly[LongEnum[EntryType]]
-      findCompanion[ContentType].values should contain(ContentType.Audio)
+      def findCompanion[EntryType <: LongEnumEntry: LongEnum](entry: EntryType) = implicitly[LongEnum[EntryType]]
+      val companion = findCompanion(ContentType.Image: ContentType)
+      companion shouldBe ContentType
+      companion.values should contain(ContentType.Audio)
     }
 
   }

--- a/enumeratum-core/src/main/scala/enumeratum/Enum.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/Enum.scala
@@ -153,16 +153,10 @@ trait Enum[A <: EnumEntry] {
 }
 
 object Enum {
-  implicit def materializeEnum[A <: EnumEntry]: Enum[A] = macro EnumMacrosAux.materializeEnumImpl[A]
-}
 
-object EnumMacrosAux {
   /**
-   * Given an A <: EnumEntry, provide Enum[A]
+   * Finds the Enum companion object for a particular EnumEntry
    */
-  def materializeEnumImpl[A <: EnumEntry: c.WeakTypeTag](c: Context) = {
-    import c.universe._
-    val symbol = weakTypeOf[A].typeSymbol
-    c.Expr[Enum[A]](Ident(symbol.companionSymbol))
-  }
+  implicit def materializeEnum[A <: EnumEntry]: Enum[A] = macro EnumMacros.materializeEnumImpl[A]
+
 }

--- a/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
@@ -369,7 +369,10 @@ class EnumSpec extends FunSpec with Matchers {
       def findEnum[A <: EnumEntry: Enum](v: A) = implicitly[Enum[A]]
 
       val hello: DummyEnum = Hello
-      findEnum(hello) shouldEqual DummyEnum
+      val companion = findEnum(hello)
+      companion shouldBe DummyEnum
+      companion.values should contain(Hello)
+
     }
   }
 }

--- a/macros/compat/src/main/scala-2.10/enumeratum/ContextUtils.scala
+++ b/macros/compat/src/main/scala-2.10/enumeratum/ContextUtils.scala
@@ -11,4 +11,9 @@ object ContextUtils {
     c.universe.newTermName(name)
   }
 
+  /**
+   * Returns a companion symbol
+   */
+  def companion(c: Context)(sym: c.Symbol): c.universe.Symbol = sym.companionSymbol
+
 }

--- a/macros/compat/src/main/scala-2.11/enumeratum/ContextUtils.scala
+++ b/macros/compat/src/main/scala-2.11/enumeratum/ContextUtils.scala
@@ -11,4 +11,9 @@ object ContextUtils {
     c.universe.TermName(name)
   }
 
+  /**
+   * Returns a companion symbol
+   */
+  def companion(c: Context)(sym: c.Symbol): c.universe.Symbol = sym.companion
+
 }

--- a/macros/src/main/scala/enumeratum/EnumMacros.scala
+++ b/macros/src/main/scala/enumeratum/EnumMacros.scala
@@ -17,6 +17,15 @@ object EnumMacros {
   }
 
   /**
+   * Given an A, provides its companion
+   */
+  def materializeEnumImpl[A: c.WeakTypeTag](c: Context) = {
+    import c.universe._
+    val symbol = weakTypeOf[A].typeSymbol
+    c.Expr[A](Ident(ContextUtils.companion(c)(symbol)))
+  }
+
+  /**
    * Makes sure that we can work with the given type as an enum:
    *
    * Aborts if the type is not sealed


### PR DESCRIPTION
- Remove restraint on companion-materialising macro and move it macro project
- Add companion finding to ValueEnums as well

Note: It's hard to generalise this for use on ValueEnum[ValueType, EntryType] ... instead it's currently implemented for each type of value enum. C'est la vie? Or not enough macro 力?