### PR TITLE
Refs #56 Feature/stringvalueenum

### DIFF
--- a/enumeratum-circe/compat/src/main/scala-2.11/enumeratum/values/Circe.scala
+++ b/enumeratum-circe/compat/src/main/scala-2.11/enumeratum/values/Circe.scala
@@ -14,7 +14,7 @@ object Circe {
   /**
    * Returns an Encoder for the provided ValueEnum
    */
-  def encoder[ValueType <: AnyVal: Encoder, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType]): Encoder[EntryType] = {
+  def encoder[ValueType: Encoder, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType]): Encoder[EntryType] = {
     new Encoder[EntryType] {
       private val valueEncoder = implicitly[Encoder[ValueType]]
       def apply(a: EntryType): Json = valueEncoder.apply(a.value)
@@ -24,7 +24,7 @@ object Circe {
   /**
    * Returns a Decoder for the provided ValueEnum
    */
-  def decoder[ValueType <: AnyVal: Decoder, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType]): Decoder[EntryType] = {
+  def decoder[ValueType: Decoder, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType]): Decoder[EntryType] = {
     new Decoder[EntryType] {
       private val valueDecoder = implicitly[Decoder[ValueType]]
       def apply(c: HCursor): Result[EntryType] = valueDecoder.apply(c).flatMap { v =>

--- a/enumeratum-circe/compat/src/main/scala-2.11/enumeratum/values/CirceValueEnum.scala
+++ b/enumeratum-circe/compat/src/main/scala-2.11/enumeratum/values/CirceValueEnum.scala
@@ -8,7 +8,7 @@ import io.circe.{ Decoder, Encoder }
  * Copyright 2016
  */
 
-sealed trait CirceValueEnum[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType]] {
+sealed trait CirceValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]] {
   this: ValueEnum[ValueType, EntryType] =>
 
   /**
@@ -42,6 +42,14 @@ trait LongCirceEnum[EntryType <: LongEnumEntry] extends CirceValueEnum[Long, Ent
  * CirceEnum for ShortEnumEntry
  */
 trait ShortCirceEnum[EntryType <: ShortEnumEntry] extends CirceValueEnum[Short, EntryType] { this: ValueEnum[Short, EntryType] =>
+  implicit val circeEncoder = Circe.encoder(this)
+  implicit val circeDecoder = Circe.decoder(this)
+}
+
+/**
+ * CirceEnum for StringEnumEntry
+ */
+trait StringCirceEnum[EntryType <: StringEnumEntry] extends CirceValueEnum[String, EntryType] { this: ValueEnum[String, EntryType] =>
   implicit val circeEncoder = Circe.encoder(this)
   implicit val circeDecoder = Circe.decoder(this)
 }

--- a/enumeratum-circe/compat/src/test/scala-2.11/enumeratum/values/CirceValueEnumSpec.scala
+++ b/enumeratum-circe/compat/src/test/scala-2.11/enumeratum/values/CirceValueEnumSpec.scala
@@ -15,10 +15,11 @@ class CirceValueEnumSpec extends FunSpec with Matchers {
   testCirceEnum("LongCirceEnum", CirceContentType)
   testCirceEnum("ShortCirceEnum", CirceDrinks)
   testCirceEnum("IntCirceEnum", CirceLibraryItem)
+  testCirceEnum("StringCirceEnum", CirceOperatingSystem)
   testCirceEnum("IntCirceEnum with val value members", CirceMovieGenre)
 
   // Test method that generates tests for most primitve-based ValueEnums when given a simple descriptor and the enum
-  private def testCirceEnum[ValueType <: AnyVal: Encoder: Decoder, EntryType <: ValueEnumEntry[ValueType]: Encoder: Decoder](enumKind: String, enum: ValueEnum[ValueType, EntryType] with CirceValueEnum[ValueType, EntryType]): Unit = {
+  private def testCirceEnum[ValueType: Encoder: Decoder, EntryType <: ValueEnumEntry[ValueType]: Encoder: Decoder](enumKind: String, enum: ValueEnum[ValueType, EntryType] with CirceValueEnum[ValueType, EntryType]): Unit = {
     describe(enumKind) {
 
       describe("to JSON") {
@@ -88,6 +89,19 @@ case object CirceLibraryItem extends IntEnum[CirceLibraryItem] with IntCirceEnum
   case object Movie extends CirceLibraryItem(name = "movie", value = 2)
   case object Magazine extends CirceLibraryItem(3, "magazine")
   case object CD extends CirceLibraryItem(4, name = "cd")
+
+  val values = findValues
+
+}
+
+sealed abstract class CirceOperatingSystem(val value: String) extends StringEnumEntry
+
+case object CirceOperatingSystem extends StringEnum[CirceOperatingSystem] with StringCirceEnum[CirceOperatingSystem] {
+
+  case object Linux extends CirceOperatingSystem("linux")
+  case object OSX extends CirceOperatingSystem("osx")
+  case object Windows extends CirceOperatingSystem("windows")
+  case object Android extends CirceOperatingSystem("android")
 
   val values = findValues
 

--- a/enumeratum-core/compat/src/main/scala-2.11/enumeratum/values/ValueEnum.scala
+++ b/enumeratum-core/compat/src/main/scala-2.11/enumeratum/values/ValueEnum.scala
@@ -4,7 +4,7 @@ import enumeratum.{ EnumMacros, ValueEnumMacros }
 
 import scala.language.experimental.macros
 
-sealed trait ValueEnum[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType]] {
+sealed trait ValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]] {
 
   /**
    * Map of [[ValueType]] to [[EntryType]] members
@@ -119,3 +119,32 @@ trait ShortEnum[A <: ShortEnumEntry] extends ValueEnum[Short, A] {
    */
   final protected def findValues: IndexedSeq[A] = macro ValueEnumMacros.findShortValueEntriesImpl[A]
 }
+
+object StringEnum {
+
+  /**
+   * Materializes a StringEnum for an in-scope StringEnumEntry
+   */
+  implicit def materialiseStringValueEnum[EntryType <: StringEnumEntry]: StringEnum[EntryType] = macro EnumMacros.materializeEnumImpl[EntryType]
+
+}
+
+/**
+ * Value enum with [[ShortEnumEntry]] entries
+ *
+ * This is similar to [[enumeratum.Enum]], but different in that values must be
+ * literal values. This restraint allows us to enforce uniqueness at compile time.
+ *
+ * Note that uniqueness is only guaranteed if you do not do any runtime string manipulation on values.
+ */
+trait StringEnum[A <: StringEnumEntry] extends ValueEnum[String, A] {
+
+  /**
+   * Method that returns a Seq of [[A]] objects that the macro was able to find.
+   *
+   * You will want to use this in some way to implement your [[values]] method. In fact,
+   * if you aren't using this method...why are you even bothering with this lib?
+   */
+  final protected def findValues: IndexedSeq[A] = macro ValueEnumMacros.findStringValueEntriesImpl[A]
+}
+

--- a/enumeratum-core/compat/src/main/scala-2.11/enumeratum/values/ValueEnumEntry.scala
+++ b/enumeratum-core/compat/src/main/scala-2.11/enumeratum/values/ValueEnumEntry.scala
@@ -6,7 +6,7 @@ package enumeratum.values
  * Copyright 2016
  */
 
-sealed trait ValueEnumEntry[ValueType <: AnyVal] {
+sealed trait ValueEnumEntry[ValueType] {
 
   /**
    * Value of this entry
@@ -53,3 +53,14 @@ abstract class LongEnumEntry extends ValueEnumEntry[Long]
  * Value Enum Entry parent class for [[Short]] valued entries
  */
 abstract class ShortEnumEntry extends ValueEnumEntry[Short]
+
+/**
+ * Value Enum Entry parent class for [[String]] valued entries
+ *
+ * This is similar to [[enumeratum.Enum]], but different in that values must be
+ * literal values. This restraint allows us to enforce uniqueness at compile time.
+ *
+ * Note that uniqueness is only guaranteed if you do not do any runtime string manipulation on values.
+ */
+abstract class StringEnumEntry extends ValueEnumEntry[String]
+

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/OperatingSystem.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/OperatingSystem.scala
@@ -1,0 +1,19 @@
+package enumeratum.values
+
+/**
+ * Created by Lloyd on 8/4/16.
+ *
+ * Copyright 2016
+ */
+sealed abstract class OperatingSystem(val value: String) extends StringEnumEntry
+
+case object OperatingSystem extends StringEnum[OperatingSystem] {
+
+  val values = findValues
+
+  case object Linux extends OperatingSystem("linux")
+  case object OSX extends OperatingSystem("osx")
+  case object Windows extends OperatingSystem("windows")
+  case object Android extends OperatingSystem("android")
+
+}

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumHelpers.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumHelpers.scala
@@ -14,8 +14,16 @@ trait ValueEnumHelpers { this: FunSpec with Matchers =>
   /*
    * Generates tests for a given enum and groups the tests inside the given enumKind descriptor
    */
-  def testEnum[EntryType <: ValueEnumEntry[ValueType], ValueType <: AnyVal: Numeric](enumKind: String, enum: ValueEnum[ValueType, EntryType]): Unit = {
+  def testNumericEnum[EntryType <: ValueEnumEntry[ValueType], ValueType <: AnyVal: Numeric](enumKind: String, enum: ValueEnum[ValueType, EntryType]): Unit = {
     val numeric = implicitly[Numeric[ValueType]]
+    testEnum(enumKind, enum, Seq(numeric.fromInt(Int.MaxValue)))
+  }
+
+  /*
+   * Generates tests for a given enum and groups the tests inside the given enumKind descriptor
+   */
+  def testEnum[EntryType <: ValueEnumEntry[ValueType], ValueType](enumKind: String, enum: ValueEnum[ValueType, EntryType], invalidValues: Seq[ValueType]): Unit = {
+
     describe(enumKind) {
 
       describe("withValue") {
@@ -27,8 +35,10 @@ trait ValueEnumHelpers { this: FunSpec with Matchers =>
         }
 
         it("should throw on values that don't map to any entries") {
-          intercept[NoSuchElementException] {
-            enum.withValue(numeric.fromInt(Int.MaxValue))
+          invalidValues.foreach { invalid =>
+            intercept[NoSuchElementException] {
+              enum.withValue(invalid)
+            }
           }
         }
 
@@ -43,7 +53,9 @@ trait ValueEnumHelpers { this: FunSpec with Matchers =>
         }
 
         it("should return None when given values that do not map to any entries") {
-          enum.withValueOpt(numeric.fromInt(Int.MaxValue)) shouldBe None
+          invalidValues.foreach { invalid =>
+            enum.withValueOpt(invalid) shouldBe None
+          }
         }
 
       }

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumSpec.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumSpec.scala
@@ -49,6 +49,13 @@ class ValueEnumSpec extends FunSpec with Matchers with ValueEnumHelpers {
       companion.values should contain(ContentType.Audio)
     }
 
+    it("should work for StringEnum") {
+      def findCompanion[EntryType <: StringEnumEntry: StringEnum](entry: EntryType) = implicitly[StringEnum[EntryType]]
+      val companion = findCompanion(OperatingSystem.Android: OperatingSystem)
+      companion shouldBe OperatingSystem
+      companion.values should contain(OperatingSystem.Windows)
+    }
+
   }
 
   describe("compilation failures") {

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumSpec.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumSpec.scala
@@ -20,10 +20,11 @@ class ValueEnumSpec extends FunSpec with Matchers with ValueEnumHelpers {
 
   }
 
-  testEnum("IntEnum", LibraryItem)
-  testEnum("ShortEnum", Drinks)
-  testEnum("LongEnum", ContentType)
-  testEnum("when using val members in the body", MovieGenre)
+  testNumericEnum("IntEnum", LibraryItem)
+  testNumericEnum("ShortEnum", Drinks)
+  testNumericEnum("LongEnum", ContentType)
+  testEnum("StringEnum", OperatingSystem, Seq("windows-phone"))
+  testNumericEnum("when using val members in the body", MovieGenre)
 
   describe("finding companion object") {
 

--- a/enumeratum-play-json/compat/src/main/scala-2.11/enumeratum/values/EnumFormats.scala
+++ b/enumeratum-play-json/compat/src/main/scala-2.11/enumeratum/values/EnumFormats.scala
@@ -12,7 +12,7 @@ object EnumFormats {
   /**
    * Returns a Reads for the provided ValueEnum based on the given base Reads for the Enum's value type
    */
-  def reads[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType])(implicit baseReads: Reads[ValueType]): Reads[EntryType] = new Reads[EntryType] {
+  def reads[ValueType, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType])(implicit baseReads: Reads[ValueType]): Reads[EntryType] = new Reads[EntryType] {
     def reads(json: JsValue): JsResult[EntryType] = baseReads.reads(json).flatMap { s =>
       val maybeBound = enum.withValueOpt(s)
       maybeBound match {
@@ -25,14 +25,14 @@ object EnumFormats {
   /**
    * Returns a Writes for the provided ValueEnum based on the given base Writes for the Enum's value type
    */
-  def writes[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType])(implicit baseWrites: Writes[ValueType]): Writes[EntryType] = new Writes[EntryType] {
+  def writes[ValueType, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType])(implicit baseWrites: Writes[ValueType]): Writes[EntryType] = new Writes[EntryType] {
     def writes(o: EntryType): JsValue = baseWrites.writes(o.value)
   }
 
   /**
    * Returns a Formats for the provided ValueEnum based on the given base Reads and Writes for the Enum's value type
    */
-  def formats[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType])(implicit baseReads: Reads[ValueType], baseWrites: Writes[ValueType]): Format[EntryType] = {
+  def formats[ValueType, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType])(implicit baseReads: Reads[ValueType], baseWrites: Writes[ValueType]): Format[EntryType] = {
     Format(reads(enum), writes(enum))
   }
 

--- a/enumeratum-play-json/compat/src/main/scala-2.11/enumeratum/values/PlayJsonValueEnum.scala
+++ b/enumeratum-play-json/compat/src/main/scala-2.11/enumeratum/values/PlayJsonValueEnum.scala
@@ -8,7 +8,7 @@ import play.api.libs.json.Format
  * Copyright 2016
  */
 
-trait PlayJsonValueEnum[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType]] { enum: ValueEnum[ValueType, EntryType] =>
+trait PlayJsonValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]] { enum: ValueEnum[ValueType, EntryType] =>
 
   /**
    * Implicit JSON format for the entries of this enum
@@ -35,5 +35,12 @@ trait LongPlayJsonValueEnum[EntryType <: LongEnumEntry] extends PlayJsonValueEnu
  * Enum implementation for Short enum members that contains an implicit Play JSON Format
  */
 trait ShortPlayJsonValueEnum[EntryType <: ShortEnumEntry] extends PlayJsonValueEnum[Short, EntryType] { this: ShortEnum[EntryType] =>
+  implicit val format: Format[EntryType] = EnumFormats.formats(this)
+}
+
+/**
+ * Enum implementation for String enum members that contains an implicit Play JSON Format
+ */
+trait StringPlayJsonValueEnum[EntryType <: StringEnumEntry] extends PlayJsonValueEnum[String, EntryType] { this: StringEnum[EntryType] =>
   implicit val format: Format[EntryType] = EnumFormats.formats(this)
 }

--- a/enumeratum-play-json/compat/src/test/scala-2.11/enumeratum/values/EnumFormatsSpec.scala
+++ b/enumeratum-play-json/compat/src/test/scala-2.11/enumeratum/values/EnumFormatsSpec.scala
@@ -1,6 +1,7 @@
 package enumeratum.values
 
 import org.scalatest._
+import play.api.libs.json.JsString
 
 /**
  * Created by Lloyd on 4/13/16.
@@ -11,26 +12,29 @@ class EnumFormatsSpec extends FunSpec with Matchers with EnumJsonFormatHelpers {
 
   describe(".reads") {
 
-    testReads("IntEnum", LibraryItem)
-    testReads("LongEnum", ContentType)
-    testReads("ShortEnum", Drinks)
+    testNumericReads("IntEnum", LibraryItem)
+    testNumericReads("LongEnum", ContentType)
+    testNumericReads("ShortEnum", Drinks)
+    testReads("StringEnum", OperatingSystem, JsString)
 
   }
 
   describe(".writes") {
 
-    testWrites("IntEnum", LibraryItem)
-    testWrites("LongEnum", ContentType)
-    testWrites("ShortEnum", Drinks)
+    testNumericWrites("IntEnum", LibraryItem)
+    testNumericWrites("LongEnum", ContentType)
+    testNumericWrites("ShortEnum", Drinks)
+    testWrites("StringEnum", OperatingSystem, JsString)
 
   }
 
   describe(".formats") {
 
-    testFormats("IntEnum", LibraryItem)
-    testFormats("LongEnum", ContentType)
-    testFormats("ShortEnum", Drinks)
-    testFormats("PlayJsonValueEnum", JsonDrinks, Some(JsonDrinks.format))
+    testNumericFormats("IntEnum", LibraryItem)
+    testNumericFormats("LongEnum", ContentType)
+    testNumericFormats("ShortEnum", Drinks)
+    testFormats("StringEnum", OperatingSystem, JsString)
+    testNumericFormats("PlayJsonValueEnum", JsonDrinks, Some(JsonDrinks.format))
 
   }
 

--- a/enumeratum-play/compat/src/main/scala-2.11/enumeratum/values/Forms.scala
+++ b/enumeratum-play/compat/src/main/scala-2.11/enumeratum/values/Forms.scala
@@ -13,11 +13,11 @@ object Forms {
   /**
    * Returns a [[ValueEnum]] mapping for Play form fields
    */
-  def enum[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType], EnumType <: ValueEnum[ValueType, EntryType]](baseFormatter: Formatter[ValueType])(enum: EnumType): Mapping[EntryType] = {
+  def enum[ValueType, EntryType <: ValueEnumEntry[ValueType], EnumType <: ValueEnum[ValueType, EntryType]](baseFormatter: Formatter[ValueType])(enum: EnumType): Mapping[EntryType] = {
     PlayForms.of(formatter(baseFormatter)(enum))
   }
 
-  private[this] def formatter[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType], EnumType <: ValueEnum[ValueType, EntryType]](baseFormatter: Formatter[ValueType])(enum: EnumType) = {
+  private[this] def formatter[ValueType, EntryType <: ValueEnumEntry[ValueType], EnumType <: ValueEnum[ValueType, EntryType]](baseFormatter: Formatter[ValueType])(enum: EnumType) = {
     new Formatter[EntryType] {
       def bind(key: String, data: Map[String, String]): Either[Seq[FormError], EntryType] = baseFormatter.bind(key, data).right.flatMap { s =>
         val maybeBound = enum.withValueOpt(s)

--- a/enumeratum-play/compat/src/main/scala-2.11/enumeratum/values/PlayFormValueEnum.scala
+++ b/enumeratum-play/compat/src/main/scala-2.11/enumeratum/values/PlayFormValueEnum.scala
@@ -9,12 +9,12 @@ import play.api.data.Mapping
  * Copyright 2016
  */
 
-sealed trait PlayFormValueEnum[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType]] { enum: ValueEnum[ValueType, EntryType] =>
+sealed trait PlayFormValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]] { enum: ValueEnum[ValueType, EntryType] =>
 
   /**
-   * The [[Formmater]] for binding the ValueType of this ValueEnum.
+   * The [[Formatter]] for binding the ValueType of this ValueEnum.
    *
-   * Used for building the [[Formmater]] for the entries
+   * Used for building the [[Formatter]] for the entries
    */
   protected def baseFormatter: Formatter[ValueType]
 
@@ -44,4 +44,11 @@ trait LongPlayFormValueEnum[EntryType <: LongEnumEntry] extends PlayFormValueEnu
  */
 trait ShortPlayFormValueEnum[EntryType <: ShortEnumEntry] extends PlayFormValueEnum[Short, EntryType] { this: ShortEnum[EntryType] =>
   protected val baseFormatter: Formatter[Short] = Formats.shortFormat
+}
+
+/**
+ * Form Bindable implicits for StringEnum
+ */
+trait StringPlayFormValueEnum[EntryType <: StringEnumEntry] extends PlayFormValueEnum[String, EntryType] { this: StringEnum[EntryType] =>
+  protected val baseFormatter: Formatter[String] = Formats.stringFormat
 }

--- a/enumeratum-play/compat/src/main/scala-2.11/enumeratum/values/PlayPathBindableValueEnum.scala
+++ b/enumeratum-play/compat/src/main/scala-2.11/enumeratum/values/PlayPathBindableValueEnum.scala
@@ -8,7 +8,7 @@ import play.api.routing.sird.PathBindableExtractor
  *
  * Copyright 2016
  */
-sealed trait PlayPathBindableValueEnum[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType]] { enum: ValueEnum[ValueType, EntryType] =>
+sealed trait PlayPathBindableValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]] { enum: ValueEnum[ValueType, EntryType] =>
 
   /**
    * Implicit path binder for Play's default router
@@ -54,4 +54,11 @@ trait LongPlayPathBindableValueEnum[EntryType <: LongEnumEntry] extends PlayPath
  */
 trait ShortPlayPathBindableValueEnum[EntryType <: ShortEnumEntry] extends PlayPathBindableValueEnum[Short, EntryType] { this: ShortEnum[EntryType] =>
   implicit val pathBindable: PathBindable[EntryType] = UrlBinders.pathBinder(this)(PathBindable.bindableInt.transform(_.toShort, _.toInt))
+}
+
+/**
+ * Path Bindable implicits for StringEnum
+ */
+trait StringPlayPathBindableValueEnum[EntryType <: StringEnumEntry] extends PlayPathBindableValueEnum[String, EntryType] { this: StringEnum[EntryType] =>
+  implicit val pathBindable: PathBindable[EntryType] = UrlBinders.pathBinder(this)(PathBindable.bindableString)
 }

--- a/enumeratum-play/compat/src/main/scala-2.11/enumeratum/values/PlayQueryBindableValueEnum.scala
+++ b/enumeratum-play/compat/src/main/scala-2.11/enumeratum/values/PlayQueryBindableValueEnum.scala
@@ -9,7 +9,7 @@ import play.api.routing.sird.PathBindableExtractor
  * Copyright 2016
  */
 
-sealed trait PlayQueryBindableValueEnum[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType]] { enum: ValueEnum[ValueType, EntryType] =>
+sealed trait PlayQueryBindableValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]] { enum: ValueEnum[ValueType, EntryType] =>
 
   /**
    * Implicit path binder for Play's default router
@@ -36,4 +36,11 @@ trait LongPlayQueryBindableValueEnum[EntryType <: LongEnumEntry] extends PlayQue
  */
 trait ShortPlayQueryBindableValueEnum[EntryType <: ShortEnumEntry] extends PlayQueryBindableValueEnum[Short, EntryType] { this: ShortEnum[EntryType] =>
   implicit val queryBindable: QueryStringBindable[EntryType] = UrlBinders.queryBinder(this)(QueryStringBindable.bindableInt.transform(_.toShort, _.toInt))
+}
+
+/**
+ * Query Bindable implicits for StringEnum
+ */
+trait StringPlayQueryBindableValueEnum[EntryType <: StringEnumEntry] extends PlayQueryBindableValueEnum[String, EntryType] { this: StringEnum[EntryType] =>
+  implicit val queryBindable: QueryStringBindable[EntryType] = UrlBinders.queryBinder(this)(QueryStringBindable.bindableString)
 }

--- a/enumeratum-play/compat/src/main/scala-2.11/enumeratum/values/PlayValueEnums.scala
+++ b/enumeratum-play/compat/src/main/scala-2.11/enumeratum/values/PlayValueEnums.scala
@@ -25,7 +25,7 @@ trait IntPlayEnum[EnumEntry <: IntEnumEntry] extends IntEnum[EnumEntry]
   with IntPlayJsonValueEnum[EnumEntry]
 
 /**
- * An LongEnum that has a lot of the Play-related implicits built-in so you can avoid
+ * A LongEnum that has a lot of the Play-related implicits built-in so you can avoid
  * boilerplate.
  *
  * Things included are:
@@ -43,7 +43,7 @@ trait LongPlayEnum[EnumEntry <: LongEnumEntry] extends LongEnum[EnumEntry]
   with LongPlayJsonValueEnum[EnumEntry]
 
 /**
- * An ShortEnum that has a lot of the Play-related implicits built-in so you can avoid
+ * A ShortEnum that has a lot of the Play-related implicits built-in so you can avoid
  * boilerplate.
  *
  * Things included are:
@@ -59,3 +59,21 @@ trait ShortPlayEnum[EnumEntry <: ShortEnumEntry] extends ShortEnum[EnumEntry]
   with ShortPlayQueryBindableValueEnum[EnumEntry]
   with ShortPlayFormValueEnum[EnumEntry]
   with ShortPlayJsonValueEnum[EnumEntry]
+
+/**
+ * A StringEnum that has a lot of the Play-related implicits built-in so you can avoid
+ * boilerplate.
+ *
+ * Things included are:
+ *
+ *   - implicit PathBindable (for binding from request path)
+ *   - implicit QueryStringBindable (for binding from query strings)
+ *   - formField for doing things like `Form("hello" -> MyEnum.formField)`
+ *   - implicit Json format
+ *
+ */
+trait StringPlayEnum[EnumEntry <: StringEnumEntry] extends StringEnum[EnumEntry]
+  with StringPlayPathBindableValueEnum[EnumEntry]
+  with StringPlayQueryBindableValueEnum[EnumEntry]
+  with StringPlayFormValueEnum[EnumEntry]
+  with StringPlayJsonValueEnum[EnumEntry]

--- a/enumeratum-play/compat/src/main/scala-2.11/enumeratum/values/UrlBinders.scala
+++ b/enumeratum-play/compat/src/main/scala-2.11/enumeratum/values/UrlBinders.scala
@@ -12,7 +12,7 @@ object UrlBinders {
   /**
    * Returns a [[PathBindable]] for the provided ValueEnum and base [[PathBindable]]
    */
-  def pathBinder[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType])(implicit baseBindable: PathBindable[ValueType]): PathBindable[EntryType] = new PathBindable[EntryType] {
+  def pathBinder[ValueType, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType])(implicit baseBindable: PathBindable[ValueType]): PathBindable[EntryType] = new PathBindable[EntryType] {
     def bind(key: String, value: String): Either[String, EntryType] = baseBindable.bind(key, value).right.flatMap { b =>
       val maybeBound = enum.withValueOpt(b)
       maybeBound match {
@@ -27,7 +27,7 @@ object UrlBinders {
   /**
    * Returns a [[QueryStringBindable]] for the provided ValueEnum and base [[PathBindable]]
    */
-  def queryBinder[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType])(implicit baseBindable: QueryStringBindable[ValueType]): QueryStringBindable[EntryType] = new QueryStringBindable[EntryType] {
+  def queryBinder[ValueType, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType])(implicit baseBindable: QueryStringBindable[ValueType]): QueryStringBindable[EntryType] = new QueryStringBindable[EntryType] {
     def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, EntryType]] = {
       baseBindable.bind(key, params).map(_.right.flatMap { s =>
         val maybeBound = enum.withValueOpt(s)

--- a/enumeratum-play/compat/src/test/scala-2.11/enumeratum/values/PlayValueEnumHelpers.scala
+++ b/enumeratum-play/compat/src/test/scala-2.11/enumeratum/values/PlayValueEnumHelpers.scala
@@ -134,7 +134,7 @@ trait PlayValueEnumHelpers extends EnumJsonFormatHelpers { this: FunSpec with Ma
         }
 
         describe("JSON formats") {
-          testFormats(enumKind, enum, Some(enum.format))
+          testNumericFormats(enumKind, enum, Some(enum.format))
         }
 
       }

--- a/enumeratum-play/compat/src/test/scala-2.11/enumeratum/values/PlayValueEnumHelpers.scala
+++ b/enumeratum-play/compat/src/test/scala-2.11/enumeratum/values/PlayValueEnumHelpers.scala
@@ -8,7 +8,7 @@ import play.api.http.HttpVerbs
 import play.api.mvc.{ Headers, RequestHeader }
 import org.scalatest.OptionValues._
 import org.scalatest.EitherValues._
-import play.api.libs.json.Format
+import play.api.libs.json.{ Format, JsNumber, JsValue }
 
 /**
  * Created by Lloyd on 4/13/16.
@@ -17,9 +17,19 @@ import play.api.libs.json.Format
  */
 trait PlayValueEnumHelpers extends EnumJsonFormatHelpers { this: FunSpec with Matchers =>
 
-  def testPlayEnum[EntryType <: ValueEnumEntry[ValueType], ValueType <: AnyVal: Numeric: Format](
+  def testNumericPlayEnum[EntryType <: ValueEnumEntry[ValueType], ValueType <: AnyVal: Numeric: Format](
     enumKind: String,
     enum:     ValueEnum[ValueType, EntryType] with PlayFormValueEnum[ValueType, EntryType] with PlayPathBindableValueEnum[ValueType, EntryType] with PlayQueryBindableValueEnum[ValueType, EntryType] with PlayJsonValueEnum[ValueType, EntryType]
+  ) = {
+    val numeric = implicitly[Numeric[ValueType]]
+    testPlayEnum(enumKind, enum, { i: ValueType => JsNumber(numeric.toInt(i)) })
+
+  }
+
+  def testPlayEnum[EntryType <: ValueEnumEntry[ValueType], ValueType: Format](
+    enumKind:  String,
+    enum:      ValueEnum[ValueType, EntryType] with PlayFormValueEnum[ValueType, EntryType] with PlayPathBindableValueEnum[ValueType, EntryType] with PlayQueryBindableValueEnum[ValueType, EntryType] with PlayJsonValueEnum[ValueType, EntryType],
+    jsWrapper: ValueType => JsValue
   ) = {
 
     describe(enumKind) {
@@ -134,7 +144,7 @@ trait PlayValueEnumHelpers extends EnumJsonFormatHelpers { this: FunSpec with Ma
         }
 
         describe("JSON formats") {
-          testNumericFormats(enumKind, enum, Some(enum.format))
+          testFormats(enumKind, enum, jsWrapper, Some(enum.format))
         }
 
       }

--- a/enumeratum-play/compat/src/test/scala-2.11/enumeratum/values/PlayValueEnumSpec.scala
+++ b/enumeratum-play/compat/src/test/scala-2.11/enumeratum/values/PlayValueEnumSpec.scala
@@ -1,6 +1,7 @@
 package enumeratum.values
 
 import org.scalatest.{ FunSpec, Matchers }
+import play.api.libs.json.JsString
 
 /**
  * Created by Lloyd on 4/13/16.
@@ -9,10 +10,11 @@ import org.scalatest.{ FunSpec, Matchers }
  */
 class PlayValueEnumSpec extends FunSpec with Matchers with PlayValueEnumHelpers {
 
-  testPlayEnum("LongPlayEnum", PlayContentType)
-  testPlayEnum("ShortPlayEnum", PlayDrinks)
-  testPlayEnum("IntPlayEnum", PlayLibraryItem)
-  testPlayEnum("IntPlayEnum with values declared as members", PlayMovieGenre)
+  testNumericPlayEnum("LongPlayEnum", PlayContentType)
+  testNumericPlayEnum("ShortPlayEnum", PlayDrinks)
+  testNumericPlayEnum("IntPlayEnum", PlayLibraryItem)
+  testPlayEnum("StringPlayEnum", PlayOperatingSystem, JsString)
+  testNumericPlayEnum("IntPlayEnum with values declared as members", PlayMovieGenre)
 
 }
 
@@ -52,6 +54,19 @@ case object PlayLibraryItem extends IntPlayEnum[PlayLibraryItem] {
   case object Movie extends PlayLibraryItem(name = "movie", value = 2)
   case object Magazine extends PlayLibraryItem(3, "magazine")
   case object CD extends PlayLibraryItem(4, name = "cd")
+
+  val values = findValues
+
+}
+
+sealed abstract class PlayOperatingSystem(val value: String) extends StringEnumEntry
+
+case object PlayOperatingSystem extends StringPlayEnum[PlayOperatingSystem] {
+
+  case object Linux extends PlayOperatingSystem("linux")
+  case object OSX extends PlayOperatingSystem("osx")
+  case object Windows extends PlayOperatingSystem("windows")
+  case object Android extends PlayOperatingSystem("android")
 
   val values = findValues
 

--- a/enumeratum-reactivemongo-bson/compat/src/main/scala-2.11/enumeratum/values/BSONValueHandlers.scala
+++ b/enumeratum-reactivemongo-bson/compat/src/main/scala-2.11/enumeratum/values/BSONValueHandlers.scala
@@ -1,6 +1,6 @@
 package enumeratum.values
 
-import reactivemongo.bson.{ BSONHandler, BSONInteger, BSONLong, BSONReader, BSONValue, BSONWriter }
+import reactivemongo.bson.{ BSONHandler, BSONInteger, BSONLong, BSONReader, BSONString, BSONValue, BSONWriter }
 
 /**
  * Created by Lloyd on 5/3/16.
@@ -24,23 +24,30 @@ object BSONValueHandlers extends BSONValueReads with BSONValueWrites {
 trait BSONValueReads {
 
   implicit val bsonReaderShort = new BSONReader[BSONValue, Short] {
-    override def read(bson: BSONValue): Short = bson match {
+    def read(bson: BSONValue): Short = bson match {
       case BSONInteger(x) if Short.MaxValue >= x && Short.MinValue <= x => x.toShort
       case _ => throw new RuntimeException(s"Could not convert $bson to Short")
     }
   }
 
   implicit val bsonReaderInt = new BSONReader[BSONValue, Int] {
-    override def read(bson: BSONValue): Int = bson match {
+    def read(bson: BSONValue): Int = bson match {
       case BSONInteger(x) => x
       case _ => throw new RuntimeException(s"Could not convert $bson to Int")
     }
   }
 
   implicit val bsonReaderLong = new BSONReader[BSONValue, Long] {
-    override def read(bson: BSONValue): Long = bson match {
+    def read(bson: BSONValue): Long = bson match {
       case BSONLong(x) => x
       case _ => throw new RuntimeException(s"Could not convert $bson to Long")
+    }
+  }
+
+  implicit val bsonReaderString = new BSONReader[BSONValue, String] {
+    def read(bson: BSONValue): String = bson match {
+      case BSONString(x) => x
+      case _ => throw new RuntimeException(s"Could not convert $bson to String")
     }
   }
 
@@ -49,15 +56,19 @@ trait BSONValueReads {
 trait BSONValueWrites {
 
   implicit val bsonWriterShort = new BSONWriter[Short, BSONValue] {
-    override def write(t: Short): BSONValue = BSONInteger(t)
+    def write(t: Short): BSONValue = BSONInteger(t)
   }
 
   implicit val bsonWriterInt = new BSONWriter[Int, BSONValue] {
-    override def write(t: Int): BSONValue = BSONInteger(t)
+    def write(t: Int): BSONValue = BSONInteger(t)
   }
 
   implicit val bsonWriterLong = new BSONWriter[Long, BSONValue] {
-    override def write(t: Long): BSONValue = BSONLong(t)
+    def write(t: Long): BSONValue = BSONLong(t)
+  }
+
+  implicit val bsonWriterString = new BSONWriter[String, BSONValue] {
+    def write(t: String): BSONValue = BSONString(t)
   }
 
 }

--- a/enumeratum-reactivemongo-bson/compat/src/main/scala-2.11/enumeratum/values/EnumHandler.scala
+++ b/enumeratum-reactivemongo-bson/compat/src/main/scala-2.11/enumeratum/values/EnumHandler.scala
@@ -13,8 +13,8 @@ object EnumHandler {
   /**
    * Returns a BSONReader for the provided ValueEnum based on the given base BSONReader for the Enum's value type
    */
-  def reader[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType])(implicit baseBsonReader: BSONReader[BSONValue, ValueType]): BSONReader[BSONValue, EntryType] = new BSONReader[BSONValue, EntryType] {
-    override def read(bson: BSONValue): EntryType = {
+  def reader[ValueType, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType])(implicit baseBsonReader: BSONReader[BSONValue, ValueType]): BSONReader[BSONValue, EntryType] = new BSONReader[BSONValue, EntryType] {
+    def read(bson: BSONValue): EntryType = {
       val value = baseBsonReader.read(bson)
       enum.withValue(value)
     }
@@ -23,18 +23,18 @@ object EnumHandler {
   /**
    * Returns a BSONWriter for the provided ValueEnum based on the given base BSONWriter for the Enum's value type
    */
-  def writer[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType])(implicit baseBsonWriter: BSONWriter[ValueType, BSONValue]): BSONWriter[EntryType, BSONValue] = new BSONWriter[EntryType, BSONValue] {
-    override def write(t: EntryType): BSONValue = baseBsonWriter.write(t.value)
+  def writer[ValueType, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType])(implicit baseBsonWriter: BSONWriter[ValueType, BSONValue]): BSONWriter[EntryType, BSONValue] = new BSONWriter[EntryType, BSONValue] {
+    def write(t: EntryType): BSONValue = baseBsonWriter.write(t.value)
   }
 
   /**
-   * Returns a BSONHandler for the provided ValueEnum based on the given
-   * base BSONReader and BSONWriter for the Enum's value type
+   * Returns a BSONHandler for the provided ValueEnum based on the given base BSONReader and BSONWriter for the
+   * Enum's value type
    */
-  def handler[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType])(implicit baseBsonHandler: BSONHandler[BSONValue, ValueType]): BSONHandler[BSONValue, EntryType] = new BSONHandler[BSONValue, EntryType] {
+  def handler[ValueType, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType])(implicit baseBsonHandler: BSONHandler[BSONValue, ValueType]): BSONHandler[BSONValue, EntryType] = new BSONHandler[BSONValue, EntryType] {
     private val concreteReader = reader(enum)
     private val concreteWriter = writer(enum)
-    override def read(bson: BSONValue): EntryType = concreteReader.read(bson)
-    override def write(t: EntryType): BSONValue = concreteWriter.write(t)
+    def read(bson: BSONValue): EntryType = concreteReader.read(bson)
+    def write(t: EntryType): BSONValue = concreteWriter.write(t)
   }
 }

--- a/enumeratum-reactivemongo-bson/compat/src/main/scala-2.11/enumeratum/values/ReactiveMongoBsonValueEnum.scala
+++ b/enumeratum-reactivemongo-bson/compat/src/main/scala-2.11/enumeratum/values/ReactiveMongoBsonValueEnum.scala
@@ -8,7 +8,7 @@ import reactivemongo.bson._
  * @since 2016-04-23
  */
 
-sealed trait ReactiveMongoBsonValueEnum[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType]] {
+sealed trait ReactiveMongoBsonValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]] {
   enum: ValueEnum[ValueType, EntryType] =>
 
   /**
@@ -40,6 +40,15 @@ trait LongReactiveMongoBsonValueEnum[EntryType <: LongEnumEntry] extends Reactiv
  */
 trait ShortReactiveMongoBsonValueEnum[EntryType <: ShortEnumEntry] extends ReactiveMongoBsonValueEnum[Short, EntryType] {
   this: ShortEnum[EntryType] =>
+
+  implicit val bsonHandler: BSONHandler[BSONValue, EntryType] = EnumHandler.handler(this)
+}
+
+/**
+ * Enum implementation for String enum members that contains an implicit ReactiveMongo BSON Handler
+ */
+trait StringReactiveMongoBsonValueEnum[EntryType <: StringEnumEntry] extends ReactiveMongoBsonValueEnum[String, EntryType] {
+  this: StringEnum[EntryType] =>
 
   implicit val bsonHandler: BSONHandler[BSONValue, EntryType] = EnumHandler.handler(this)
 }

--- a/enumeratum-reactivemongo-bson/compat/src/test/scala-2.11/enumeratum/values/BsonEnums.scala
+++ b/enumeratum-reactivemongo-bson/compat/src/test/scala-2.11/enumeratum/values/BsonEnums.scala
@@ -45,3 +45,16 @@ case object BsonLibraryItem extends IntEnum[BsonLibraryItem] with IntReactiveMon
   val values = findValues
 
 }
+
+sealed abstract class BsonOperatingSystem(val value: String) extends StringEnumEntry
+
+case object BsonOperatingSystem extends StringEnum[BsonOperatingSystem] with StringReactiveMongoBsonValueEnum[BsonOperatingSystem] {
+
+  case object Linux extends BsonOperatingSystem("linux")
+  case object OSX extends BsonOperatingSystem("osx")
+  case object Windows extends BsonOperatingSystem("windows")
+  case object Android extends BsonOperatingSystem("android")
+
+  val values = findValues
+
+}

--- a/enumeratum-reactivemongo-bson/compat/src/test/scala-2.11/enumeratum/values/EnumBsonHandlerHelpers.scala
+++ b/enumeratum-reactivemongo-bson/compat/src/test/scala-2.11/enumeratum/values/EnumBsonHandlerHelpers.scala
@@ -9,7 +9,7 @@ import reactivemongo.bson._
  */
 trait EnumBsonHandlerHelpers { this: FunSpec with Matchers =>
 
-  def testWriter[EntryType <: ValueEnumEntry[ValueType], ValueType <: AnyVal](
+  def testWriter[EntryType <: ValueEnumEntry[ValueType], ValueType](
     enumKind:       String,
     enum:           ValueEnum[ValueType, EntryType],
     providedWriter: Option[BSONWriter[EntryType, BSONValue]] = None
@@ -24,7 +24,7 @@ trait EnumBsonHandlerHelpers { this: FunSpec with Matchers =>
     }
   }
 
-  def testReader[EntryType <: ValueEnumEntry[ValueType], ValueType <: AnyVal](
+  def testReader[EntryType <: ValueEnumEntry[ValueType], ValueType](
     enumKind:       String,
     enum:           ValueEnum[ValueType, EntryType],
     providedReader: Option[BSONReader[BSONValue, EntryType]] = None
@@ -43,14 +43,16 @@ trait EnumBsonHandlerHelpers { this: FunSpec with Matchers =>
     }
   }
 
-  def testHandler[EntryType <: ValueEnumEntry[ValueType], ValueType <: AnyVal](
+  def testHandler[EntryType <: ValueEnumEntry[ValueType], ValueType](
     enumKind:        String,
     enum:            ValueEnum[ValueType, EntryType],
     providedHandler: Option[BSONHandler[BSONValue, EntryType]] = None
   )(implicit baseHandler: BSONHandler[BSONValue, ValueType]): Unit = {
     val handler = providedHandler.getOrElse(EnumHandler.handler(enum))
-    testReader(enumKind, enum, Some(handler))
-    testWriter(enumKind, enum, Some(handler))
+    describe(s"$enumKind Handler") {
+      testReader(enumKind, enum, Some(handler))
+      testWriter(enumKind, enum, Some(handler))
+    }
   }
 
 }

--- a/enumeratum-reactivemongo-bson/compat/src/test/scala-2.11/enumeratum/values/EnumBsonHandlerSpec.scala
+++ b/enumeratum-reactivemongo-bson/compat/src/test/scala-2.11/enumeratum/values/EnumBsonHandlerSpec.scala
@@ -14,6 +14,7 @@ class EnumBsonHandlerSpec extends FunSpec with Matchers with EnumBsonHandlerHelp
     testReader("IntEnum", LibraryItem)
     testReader("LongEnum", ContentType)
     testReader("ShortEnum", Drinks)
+    testReader("StringEnum", OperatingSystem)
 
   }
 
@@ -22,6 +23,7 @@ class EnumBsonHandlerSpec extends FunSpec with Matchers with EnumBsonHandlerHelp
     testWriter("IntEnum", LibraryItem)
     testWriter("LongEnum", ContentType)
     testWriter("ShortEnum", Drinks)
+    testWriter("StringEnum", OperatingSystem)
 
   }
 
@@ -30,9 +32,11 @@ class EnumBsonHandlerSpec extends FunSpec with Matchers with EnumBsonHandlerHelp
     testHandler("IntEnum", LibraryItem)
     testHandler("LongEnum", ContentType)
     testHandler("ShortEnum", Drinks)
+    testHandler("StringEnum", OperatingSystem)
     testHandler("ShortReactiveMongoBsonValueEnum", BsonDrinks, Some(BsonDrinks.bsonHandler))
     testHandler("LongReactiveMongoBsonValueEnum", BsonContentType, Some(BsonContentType.bsonHandler))
     testHandler("IntReactiveMongoBsonValueEnum", BsonLibraryItem, Some(BsonLibraryItem.bsonHandler))
+    testHandler("StringReactiveMongoBsonValueEnum", BsonOperatingSystem, Some(BsonOperatingSystem.bsonHandler))
 
   }
 

--- a/enumeratum-upickle/compat/src/main/scala-2.11/enumeratum/values/UPickleValueEnum.scala
+++ b/enumeratum-upickle/compat/src/main/scala-2.11/enumeratum/values/UPickleValueEnum.scala
@@ -10,7 +10,7 @@ import UPickler._
  * Copyright 2016
  */
 
-sealed trait UPickleValueEnum[ValueType <: AnyVal, EntryType <: ValueEnumEntry[ValueType]] { this: ValueEnum[ValueType, EntryType] =>
+sealed trait UPickleValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]] { this: ValueEnum[ValueType, EntryType] =>
 
   /**
    * Implicit UPickle ReadWriter
@@ -37,5 +37,12 @@ trait LongUPickleEnum[EntryType <: LongEnumEntry] extends UPickleValueEnum[Long,
  * Enum implementation for Short enum members that contains an implicit UPickle ReadWriter
  */
 trait ShortUPickleEnum[EntryType <: ShortEnumEntry] extends UPickleValueEnum[Short, EntryType] { this: ValueEnum[Short, EntryType] =>
+  implicit val uPickleReadWriter: RW[EntryType] = ReadWriter(writer(this).write, reader(this).read)
+}
+
+/**
+ * Enum implementation for String enum members that contains an implicit UPickle ReadWriter
+ */
+trait StringUPickleEnum[EntryType <: StringEnumEntry] extends UPickleValueEnum[String, EntryType] { this: ValueEnum[String, EntryType] =>
   implicit val uPickleReadWriter: RW[EntryType] = ReadWriter(writer(this).write, reader(this).read)
 }

--- a/enumeratum-upickle/compat/src/main/scala-2.11/enumeratum/values/UPickler.scala
+++ b/enumeratum-upickle/compat/src/main/scala-2.11/enumeratum/values/UPickler.scala
@@ -13,7 +13,7 @@ object UPickler {
   /**
    * Returns a Reader for the given ValueEnum
    */
-  def reader[ValueType <: AnyVal: Reader, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType]): Reader[EntryType] = {
+  def reader[ValueType: Reader, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType]): Reader[EntryType] = {
     val valueReader = implicitly[Reader[ValueType]]
     Reader[EntryType] {
       valueReader.read.andThenPartial { case v if enum.withValueOpt(v).isDefined => enum.withValue(v) }
@@ -23,7 +23,7 @@ object UPickler {
   /**
    * Returns a Writer for the given ValueEnum
    */
-  def writer[ValueType <: AnyVal: Writer, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType]): Writer[EntryType] = {
+  def writer[ValueType: Writer, EntryType <: ValueEnumEntry[ValueType]](enum: ValueEnum[ValueType, EntryType]): Writer[EntryType] = {
     val valueWriter = implicitly[Writer[ValueType]]
     Writer[EntryType] {
       case member => valueWriter.write(member.value)

--- a/enumeratum-upickle/compat/src/test/scala-2.11/enumeratum/values/UPicklerSpec.scala
+++ b/enumeratum-upickle/compat/src/test/scala-2.11/enumeratum/values/UPicklerSpec.scala
@@ -14,12 +14,13 @@ class UPicklerSpec extends FunSpec with Matchers {
   testPickling("LongUPickleEnum", UPickleContentType)
   testPickling("ShortUPickleEnum", UPickleDrinks)
   testPickling("IntUPickleEnum", UPickleLibraryItem)
+  testPickling("StringUPickleEnum", UPickleOperatingSystem)
   testPickling("IntUPickleEnum with values declared as members", UPickleMovieGenre)
 
   /**
    * Given an enum, tests its JSON reading and writing behaviour, grouping the test results under the given enumKind descriptor
    */
-  private def testPickling[ValueType <: AnyVal: Writer: Numeric, EntryType <: ValueEnumEntry[ValueType]: Reader: Writer](enumKind: String, enum: UPickleValueEnum[ValueType, EntryType] with ValueEnum[ValueType, EntryType]) = {
+  private def testPickling[ValueType: Writer, EntryType <: ValueEnumEntry[ValueType]: Reader: Writer](enumKind: String, enum: UPickleValueEnum[ValueType, EntryType] with ValueEnum[ValueType, EntryType]) = {
     describe(enumKind) {
       describe("Reader") {
 
@@ -44,7 +45,6 @@ class UPicklerSpec extends FunSpec with Matchers {
       describe("Writer") {
 
         it("should write enum values to JS") {
-          val numeric = implicitly[Numeric[ValueType]]
           val valueTypeWriter = implicitly[Writer[ValueType]]
           enum.values.foreach { entry =>
             writeJs(entry) shouldBe valueTypeWriter.write(entry.value)
@@ -94,6 +94,19 @@ case object UPickleLibraryItem extends IntEnum[UPickleLibraryItem] with IntUPick
   case object Movie extends UPickleLibraryItem(name = "movie", value = 2)
   case object Magazine extends UPickleLibraryItem(3, "magazine")
   case object CD extends UPickleLibraryItem(4, name = "cd")
+
+  val values = findValues
+
+}
+
+sealed abstract class UPickleOperatingSystem(val value: String) extends StringEnumEntry
+
+case object UPickleOperatingSystem extends StringEnum[UPickleOperatingSystem] with StringUPickleEnum[UPickleOperatingSystem] {
+
+  case object Linux extends UPickleOperatingSystem("linux")
+  case object OSX extends UPickleOperatingSystem("osx")
+  case object Windows extends UPickleOperatingSystem("windows")
+  case object Android extends UPickleOperatingSystem("android")
 
   val values = findValues
 

--- a/macros/compat/src/main/scala-2.11/enumeratum/ValueEnumMacros.scala
+++ b/macros/compat/src/main/scala-2.11/enumeratum/ValueEnumMacros.scala
@@ -36,9 +36,20 @@ object ValueEnumMacros {
   }
 
   /**
+   * Finds ValueEntryType-typed objects in scope that have literal value:String implementations
+   *
+   * Note
+   *
+   *  - requires the ValueEntryType to have a 'value' member that has a literal value
+   */
+  def findStringValueEntriesImpl[ValueEntryType: c.WeakTypeTag](c: Context): c.Expr[IndexedSeq[ValueEntryType]] = {
+    findValueEntriesImpl[ValueEntryType, String, String](c)(identity)
+  }
+
+  /**
    * The method that does the heavy lifting.
    */
-  private[this] def findValueEntriesImpl[ValueEntryType: c.WeakTypeTag, ValueType <: AnyVal: ClassTag, ProcessedValue](c: Context)(processFoundValues: ValueType => ProcessedValue): c.Expr[IndexedSeq[ValueEntryType]] = {
+  private[this] def findValueEntriesImpl[ValueEntryType: c.WeakTypeTag, ValueType: ClassTag, ProcessedValue](c: Context)(processFoundValues: ValueType => ProcessedValue): c.Expr[IndexedSeq[ValueEntryType]] = {
     import c.universe._
     val typeSymbol = weakTypeOf[ValueEntryType].typeSymbol
     EnumMacros.validateType(c)(typeSymbol)
@@ -137,7 +148,7 @@ object ValueEnumMacros {
     if (valuesWithOneSymbol.size != membersWithValues.toMap.keys.size) {
       c.abort(
         c.enclosingPosition,
-        s"It does not look like you have unique values. Found the following values correspond to more than one members: $valuesWithMoreThanOneSymbol"
+        s"It does not look like you have unique values. Each of the following values correspond to more than one member: $valuesWithMoreThanOneSymbol"
       )
     }
   }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -18,12 +18,12 @@ object Enumeratum extends Build {
   lazy val theScalaVersion = "2.11.8"
   lazy val scalaVersions = Seq("2.10.6", "2.11.8")
   def thePlayVersion(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
-    case Some((2, scalaMajor)) if scalaMajor >= 11 => "2.5.3"
-    case Some((2, scalaMajor)) if scalaMajor == 10 => "2.4.6"
+    case Some((2, scalaMajor)) if scalaMajor >= 11 => "2.5.4"
+    case Some((2, scalaMajor)) if scalaMajor == 10 => "2.4.8"
     case _ => throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
   }
   lazy val scalaTestVersion = "3.0.0-M16-SNAP3"
-  lazy val reactiveMongoVersion = "0.11.11"
+  lazy val reactiveMongoVersion = "0.11.14"
 
   lazy val root = Project(id = "enumeratum-root", base = file("."), settings = commonWithPublishSettings)
     .settings(
@@ -125,7 +125,7 @@ object Enumeratum extends Build {
           else
             CrossVersion.binary
         }
-        Seq(impl.ScalaJSGroupID.withCross("com.lihaoyi", "upickle", cross) % "0.3.9")
+        Seq(impl.ScalaJSGroupID.withCross("com.lihaoyi", "upickle", cross) % "0.4.1")
       } ++ {
         val additionalMacroDeps = CrossVersion.partialVersion(scalaVersion.value) match {
           // if scala 2.11+ is used, quasiquotes are merged into scala-reflect

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,6 +18,6 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
 // Provides auto-generating and publishing a gh-pages site
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.9")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.11")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.6")


### PR DESCRIPTION
Closes #56

Changes:

- Remove `<: AnyVal` type constraints across the board in order to support non-Primitive values
- Add `StringEnum` and `StringEnumEntry`
- Bumps versions 
- Add integrations for:
  - [x] Circe
  - [x] Play-Json
  - [x] Play
  - [x] ReactiveMongo
  - [x] UPickle
