### PR TITLE
Closes #60 Add support for nested ValueEnums

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,7 @@ LibraryItem.withValue(10) // => java.util.NoSuchElementException:
 
 **Restrictions**
 - `ValueEnum`s must have their value members implemented as literal values.
-- `ValueEnum`s cannot be nested (e.g. declaring one enum inside another)
-- `ValueEnum`s are not available in Scala 2.10.x and does not work in the REPL because constructor argument calls are not yet
-   typed during macro expansion (`fun.tpe` returns `null`).
+- `ValueEnum`s are not available in Scala 2.10.x because constructor argument calls are not yet typed during macro expansion (`fun.tpe` returns `null`).
 
 
 ## ScalaJS

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ LibraryItem.withValue(10) // => java.util.NoSuchElementException:
 
 **Restrictions**
 - `ValueEnum`s must have their value members implemented as literal values.
-- `ValueEnum`s are not available in Scala 2.10.x because constructor argument calls are not yet typed during macro expansion (`fun.tpe` returns `null`).
+- `ValueEnum`s are not available in Scala 2.10.x because work needs to be done to bridge all Macro API differences (e.g. `isConstructor`)
 
 
 ## ScalaJS
@@ -740,8 +740,7 @@ is acceptable for almost all use-cases. PRs that promise to increase performance
 
 ## Known issues
 
-1. `ValueEnum`s is not available in Scala 2.10.x and does not work in the REPL because constructor function calls are not yet
-   typed during macro expansion (`fun.tpe` returns `null`).
+1. `ValueEnum`s are not available in Scala 2.10.x because work needs to be done to bridge all Macro API differences (e.g. `isConstructor`) 
 
 ## Licence
 

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/Animal.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/Animal.scala
@@ -1,0 +1,32 @@
+package enumeratum.values
+
+/**
+ * Created by Lloyd on 8/22/16.
+ *
+ * Copyright 2016
+ */
+
+sealed abstract class Animal(val value: Long) extends LongEnumEntry
+
+case object Animal extends LongEnum[Animal] {
+
+  val values = findValues
+
+  case object Plant extends Animal(1L)
+  case object Reptile extends Animal(2L)
+  case object Mammal extends Animal(3L)
+
+  sealed abstract class Mammalian(val value: Int) extends IntEnumEntry
+
+  object Mammalian extends IntEnum[Mammalian] {
+
+    val values = findValues
+
+    case object Dog extends Mammalian(1)
+    case object Cat extends Mammalian(2)
+    case object Whale extends Mammalian(3)
+    case object Mouse extends Mammalian(4)
+    case object Human extends Mammalian(5)
+
+  }
+}

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumHelpers.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumHelpers.scala
@@ -27,7 +27,6 @@ trait ValueEnumHelpers { this: FunSpec with Matchers =>
     describe(enumKind) {
 
       it("should have more than one value (sanity test)") {
-        println(enum.values)
         enum.values.size should be > 0
       }
 

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumHelpers.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumHelpers.scala
@@ -26,6 +26,11 @@ trait ValueEnumHelpers { this: FunSpec with Matchers =>
 
     describe(enumKind) {
 
+      it("should have more than one value (sanity test)") {
+        println(enum.values)
+        enum.values.size should be > 0
+      }
+
       describe("withValue") {
 
         it("should return entries that match the value") {

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumSpec.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumSpec.scala
@@ -25,6 +25,8 @@ class ValueEnumSpec extends FunSpec with Matchers with ValueEnumHelpers {
   testNumericEnum("LongEnum", ContentType)
   testEnum("StringEnum", OperatingSystem, Seq("windows-phone"))
   testNumericEnum("when using val members in the body", MovieGenre)
+  testNumericEnum("LongEnum that is nesting an IntEnum", Animal)
+  testNumericEnum("IntEnum that is nested inside a Long Enum", Animal.Mammalian)
 
   describe("finding companion object") {
 

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumSpec.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumSpec.scala
@@ -26,7 +26,7 @@ class ValueEnumSpec extends FunSpec with Matchers with ValueEnumHelpers {
   testEnum("StringEnum", OperatingSystem, Seq("windows-phone"))
   testNumericEnum("when using val members in the body", MovieGenre)
   testNumericEnum("LongEnum that is nesting an IntEnum", Animal)
-  testNumericEnum("IntEnum that is nested inside a Long Enum", Animal.Mammalian)
+  testNumericEnum("IntEnum that is nested inside a LongEnum", Animal.Mammalian)
 
   describe("finding companion object") {
 


### PR DESCRIPTION
By resolving the constructor of `ValueEntryType`'s parameters lists using its `WeakTypeTag`,
we no longer care if the constructor method call's `.tpe` returns null when the enum members are instantiated.

Subsequently, `ValueEnum`s now work in the REPL.

This opens the door to porting `ValueEnum`s to 2.10.x, but there are still a few API differences that need to be bridged, such as `isConstructor`, `paramsList`, and `TermName` extractor.

Closes #60 