### PR TITLE
Closes #66 Fix ValueEnums not working with private constructors

### DIFF
--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/CustomEnumPrivateConstructor.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/CustomEnumPrivateConstructor.scala
@@ -1,0 +1,25 @@
+package enumeratum.values
+
+/**
+ * Code from @zifeo
+ */
+trait CustomEnumEntry extends IntEnumEntry {
+  val value: Int
+  val name: String
+}
+trait CustomEnum[T <: CustomEnumEntry] extends IntEnum[T] {
+  def apply(name: String): T =
+    values.find(_.name == name).get
+}
+trait CustomEnumComparable[T <: CustomEnumEntry] {
+  this: T =>
+  def >=(that: T): Boolean =
+    this.value >= that.value
+}
+sealed abstract class CustomEnumPrivateConstructor private (val value: Int, val name: String)
+  extends CustomEnumEntry with CustomEnumComparable[CustomEnumPrivateConstructor]
+object CustomEnumPrivateConstructor extends CustomEnum[CustomEnumPrivateConstructor] {
+  val values = findValues
+  case object A extends CustomEnumPrivateConstructor(10, "a")
+  case object B extends CustomEnumPrivateConstructor(20, "b")
+}

--- a/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumSpec.scala
+++ b/enumeratum-core/compat/src/test/scala-2.11/enumeratum/values/ValueEnumSpec.scala
@@ -27,6 +27,7 @@ class ValueEnumSpec extends FunSpec with Matchers with ValueEnumHelpers {
   testNumericEnum("when using val members in the body", MovieGenre)
   testNumericEnum("LongEnum that is nesting an IntEnum", Animal)
   testNumericEnum("IntEnum that is nested inside a LongEnum", Animal.Mammalian)
+  testNumericEnum("Custom IntEnum with private constructors", CustomEnumPrivateConstructor)
 
   describe("finding companion object") {
 

--- a/macros/compat/src/main/scala-2.11/enumeratum/ValueEnumMacros.scala
+++ b/macros/compat/src/main/scala-2.11/enumeratum/ValueEnumMacros.scala
@@ -149,7 +149,7 @@ object ValueEnumMacros {
     val valueEntryTypeTpe = implicitly[c.WeakTypeTag[ValueEntryType]].tpe
     val valueEntryTypeTpeMembers = valueEntryTypeTpe.members
     valueEntryTypeTpeMembers.collect {
-      case m if m.isMethod && m.isPublic && m.isConstructor => m.asMethod.paramLists.flatten.map(_.asTerm.name)
+      case m if m.isMethod && m.isConstructor => m.asMethod.paramLists.flatten.map(_.asTerm.name)
     }.toList
   }
 


### PR DESCRIPTION
In 1.4.11, the macro started only looking for public constructor methods. There was no reason
for this change at all, so it has been reverted.

A test case has been added to prevent regressions.