### PR TITLE
Remove unnecessary filter in enclosedSubClassTrees etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Enumeratum has the following niceties:
 - [`ValueEnum`s](#valueenum) that map to various primitive values and have compile-time uniqueness constraints. 
 - Idiomatic: you're very clearly still writing Scala, and no funny colours in your IDE means less cognitive overhead for your team
 - Simplicity; most of the complexity in this lib is in its macro, and the macro is fairly simple conceptually
-- No usage of reflection at run time. This may also help with performance but it means Enumeratum is compatible with ScalaJS and other
+- No usage of reflection at runtime. This may also help with performance but it means Enumeratum is compatible with ScalaJS and other
   environments where reflection is a best effort (such as Android)
 - No usage of `synchronized`, which may help with performance and deadlocks prevention
 - All magic happens at compile-time so you know right away when things go awry

--- a/enumeratum-core/src/main/scala/enumeratum/values/ValueEnum.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/values/ValueEnum.scala
@@ -107,7 +107,7 @@ trait LongEnum[A <: LongEnumEntry] extends ValueEnum[Long, A] {
 object ShortEnum {
 
   /**
-    * Materializes a ShortEnum for an inscope ShortEnumEntry
+    * Materializes a ShortEnum for an in-scope ShortEnumEntry
     */
   implicit def materialiseShortValueEnum[EntryType <: ShortEnumEntry]: ShortEnum[EntryType] =
     macro EnumMacros.materializeEnumImpl[EntryType]

--- a/enumeratum-core/src/main/scala/enumeratum/values/ValueEnumEntry.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/values/ValueEnumEntry.scala
@@ -16,7 +16,7 @@ sealed trait ValueEnumEntry[ValueType] {
 
 object ValueEnumEntry {
 
-  implicit class ValueEnumOps[A <: ValueEnumEntry[_]](val enumEntry: A) {
+  implicit class ValueEnumOps[A <: ValueEnumEntry[_]](val enumEntry: A) extends AnyVal {
 
     /**
       * Checks if the current enum value is contained by the set of enum values in the parameter list.

--- a/macros/src/main/scala/enumeratum/EnumMacros.scala
+++ b/macros/src/main/scala/enumeratum/EnumMacros.scala
@@ -70,11 +70,8 @@ object EnumMacros {
       }
       enclosingModule.impl.body.filter { x =>
         try {
-          Option(x.symbol) match {
-            case Some(sym) if sym.isModule =>
-              sym.asModule.moduleClass.asClass.baseClasses.contains(typeSymbol)
-            case _ => false
-          }
+          x.symbol.isModule &&
+          x.symbol.asModule.moduleClass.asClass.baseClasses.contains(typeSymbol)
         } catch {
           case NonFatal(e) =>
             c.warning(
@@ -87,9 +84,7 @@ object EnumMacros {
       case NonFatal(e) =>
         c.abort(c.enclosingPosition, s"Unexpected error: ${e.getMessage}")
     }
-    if (!enclosingBodySubClassTrees.forall(x => x.symbol.isModule))
-      c.abort(c.enclosingPosition, "All subclasses must be objects.")
-    else enclosingBodySubClassTrees
+    enclosingBodySubClassTrees
   }
 
   /**
@@ -106,7 +101,7 @@ object EnumMacros {
   private[enumeratum] def buildSeqExpr[A: c.WeakTypeTag](c: Context)(
       subclassSymbols: Seq[c.universe.Symbol]) = {
     import c.universe._
-    val resultType = implicitly[c.WeakTypeTag[A]].tpe
+    val resultType = weakTypeOf[A]
     if (subclassSymbols.isEmpty) {
       c.Expr[IndexedSeq[A]](reify(IndexedSeq.empty[A]).tree)
     } else {


### PR DESCRIPTION
This PR
- Extends ValueEnumOps to value class.
- Remove unnecessary filter in enclosedSubClassTrees method (`isModule` filter had already been applied on `enclosingBodySubClassTrees` in preceding `enclosingModule.impl.body.filter`)
- Fix some trivial typos.