### PR TITLE
Additional stackable traits added to EnumEntry

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ richer enum values without having to maintain your own collection of values.
 Enumeratum has the following niceties:
 
 - Zero dependencies
-- Performant: Faster than`Enumeration` in the standard library (see [benchmarks](#benchmarking)) 
+- Performant: Faster than`Enumeration` in the standard library (see [benchmarks](#benchmarking))
 - Allows your Enum members to be full-fledged normal objects with methods, values, inheritance, etc.
-- [`ValueEnum`s](#valueenum) that map to various primitive values and have compile-time uniqueness constraints. 
+- [`ValueEnum`s](#valueenum) that map to various primitive values and have compile-time uniqueness constraints.
 - Idiomatic: you're very clearly still writing Scala, and no funny colours in your IDE means less cognitive overhead for your team
 - Simplicity; most of the complexity in this lib is in its macro, and the macro is fairly simple conceptually
 - No usage of reflection at runtime. This may also help with performance but it means Enumeratum is compatible with ScalaJS and other
@@ -147,7 +147,7 @@ Greeting.indexOf(Bye)
 ```
 
 The name is taken from the `toString` method of the particular
-`EnumEntry`. This behavior can be changed in two ways. 
+`EnumEntry`. This behavior can be changed in two ways.
 
 
 #### Manual override of name
@@ -177,7 +177,7 @@ State.withName("AL")
 #### Mixins to override the name
 
 The second way to override the name behaviour is to mixin the stackable traits provided for common string
-conversions, `Snakecase`, `Uppercase`, and `Lowercase`.
+conversions, `Snakecase`, `UpperSnakecase`, `CapitalSnakecase`, `Hyphencase`, `UpperHyphencase`, `CapitalHyphencase`, `Dotcase`, `UpperDotcase`, `CapitalDotcase`, `Words`, `UpperWords`, `CapitalWords`, `Uppercase`, and `Lowercase`.
 
 ```scala
 
@@ -205,7 +205,7 @@ Greeting.withName("SHOUT_GOOD_BYE")
 ### ValueEnum
 
 Asides from enumerations that resolve members from `String` _names_, Enumeratum also supports `ValueEnum`s, enums that resolve
-members from simple _values_ like `Int`, `Long`, `Short`, `Char`, `Byte`, and `String` (without support for runtime transformations). 
+members from simple _values_ like `Int`, `Long`, `Short`, `Char`, `Byte`, and `String` (without support for runtime transformations).
 
 These enums are not modelled after `Enumeration` from standard lib, and therefore have the added ability to make sure, at compile-time,
 that multiple members do not share the same value.
@@ -381,14 +381,14 @@ object Formats {
 
 object GreetingForm {
   import Formats._
-  
+
   val form = Form(
       mapping(
         "name" -> nonEmptyText,
         "greeting" -> of[Greeting]
       )(Data.apply)(Data.unapply)
     )
-  
+
     case class Data(
       name: String,
       greeting: Greeting)
@@ -837,5 +837,5 @@ Other than the methods that throw `NoSuchElementException`s, performance is in t
 is acceptable for almost all use-cases. PRs that promise to increase performance are expected to be demonstrably faster.
 
 Also, Enumeratum's `withName` is faster than the standard library's `Enumeration`, by around 4x in the case where an entry exists with the given name.
-My guess is this is because Enumeratum doesn't use any `synchronized` calls or `volatile` annotations. It is also faster in the case where there is no 
-corresponding name, but not by a significant amount, perhaps because the high cost of throwing an exception masks any benefits. 
+My guess is this is because Enumeratum doesn't use any `synchronized` calls or `volatile` annotations. It is also faster in the case where there is no
+corresponding name, but not by a significant amount, perhaps because the high cost of throwing an exception masks any benefits.

--- a/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
@@ -9,7 +9,7 @@ import java.util.regex.Pattern
   * toString, but feel free to override to fit your needs.
   *
   * Mix in the supplied stackable traits to convert the entryName to [[EnumEntry.Snakecase Snakecase]],
-  * [[EnumEntry.Uppercase Uppercase]], and [[EnumEntry.Lowercase Lowercase]]
+  * [[EnumEntry.Uppercase Uppercase]], [[EnumEntry.Lowercase Lowercase]] etc.
   */
 abstract class EnumEntry {
 
@@ -29,22 +29,46 @@ object EnumEntry {
    *
    * http://stackoverflow.com/a/19832063/1814775
    */
-  private val snakifyRegexp1     = Pattern.compile("([A-Z]+)([A-Z][a-z])")
-  private val snakifyRegexp2     = Pattern.compile("([a-z\\d])([A-Z])")
-  private val snakifyReplacement = "$1_$2"
+  private val regexp1     = Pattern.compile("([A-Z]+)([A-Z][a-z])")
+  private val regexp2     = Pattern.compile("([a-z\\d])([A-Z])")
+  private val replacement = "$1_$2"
+
+  // Adapted from Lift's StringHelpers#snakify https://github.com/lift/framework/blob/a3075e0676d60861425281427aa5f57c02c3b0bc/core/util/src/main/scala/net/liftweb/util/StringHelpers.scala#L91
+  private def camel2WordArray(name: String) = {
+    val first = regexp1.matcher(name).replaceAll(replacement)
+    regexp2.matcher(first).replaceAll(replacement).split("_")
+  }
 
   /**
-    * Stackable trait to convert the entryName to snake_case. For UPPER_SNAKE_CASE,
-    * also mix in [[Uppercase]] after this one.
+    * Stackable trait to convert the entryName to Capital_Snake_Case .
     */
-  trait Snakecase extends EnumEntry {
-    abstract override def entryName: String = camel2snake(super.entryName)
+  trait CapitalSnakecase extends EnumEntry {
+    abstract override def entryName: String =
+      camel2WordArray(super.entryName).mkString("_")
+  }
 
-    // Taken from Lift's StringHelpers#snakify https://github.com/lift/framework/blob/a3075e0676d60861425281427aa5f57c02c3b0bc/core/util/src/main/scala/net/liftweb/util/StringHelpers.scala#L91
-    private def camel2snake(name: String) = {
-      val first = snakifyRegexp1.matcher(name).replaceAll(snakifyReplacement)
-      snakifyRegexp2.matcher(first).replaceAll(snakifyReplacement).toLowerCase
-    }
+  /**
+    * Stackable trait to convert the entryName to Capital-Hyphen-Case.
+    */
+  trait CapitalHyphencase extends EnumEntry {
+    abstract override def entryName: String =
+      camel2WordArray(super.entryName).mkString("-")
+  }
+
+  /**
+    * Stackable trait to convert the entryName to Capital.Dot.Case.
+    */
+  trait CapitalDotcase extends EnumEntry {
+    abstract override def entryName: String =
+      camel2WordArray(super.entryName).mkString(".")
+  }
+
+  /**
+    * Stackable trait to convert the entryName to Capital Words.
+    */
+  trait CapitalWords extends EnumEntry {
+    abstract override def entryName: String =
+      camel2WordArray(super.entryName).mkString(" ")
   }
 
   /**
@@ -60,6 +84,46 @@ object EnumEntry {
   trait Lowercase extends EnumEntry {
     abstract override def entryName: String = super.entryName.toLowerCase
   }
+
+  /**
+    * Stackable trait to convert the entryName to snake_case.
+    */
+  trait Snakecase extends EnumEntry with CapitalSnakecase with Lowercase
+
+  /**
+    * Stackable trait to convert the entryName to UPPER_SNAKE_CASE
+    */
+  trait UpperSnakecase extends EnumEntry with CapitalSnakecase with Uppercase
+
+  /**
+    * Stackable trait to convert the entryName to hyphen-case.
+    */
+  trait Hyphencase extends EnumEntry with CapitalHyphencase with Lowercase
+
+  /**
+    * Stackable trait to convert the entryName to UPPER-HYPHEN-CASE.
+    */
+  trait UpperHyphencase extends EnumEntry with CapitalHyphencase with Uppercase
+
+  /**
+    * Stackable trait to convert the entryName to dot.case.
+    */
+  trait Dotcase extends EnumEntry with CapitalDotcase with Lowercase
+
+  /**
+    * Stackable trait to convert the entryName to UPPER.DOT.CASE
+    */
+  trait UpperDotcase extends EnumEntry with CapitalDotcase with Uppercase
+
+  /**
+    * Stackable trait to convert the entryName to words.
+    */
+  trait Words extends EnumEntry with CapitalWords with Lowercase
+
+  /**
+    * Stackable trait to convert the entryName to UPPER WORDS.
+    */
+  trait UpperWords extends EnumEntry with CapitalWords with Uppercase
 
   /**
     * Helper implicit class that holds enrichment methods

--- a/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
@@ -251,6 +251,54 @@ class EnumSpec extends FunSpec with Matchers {
         SnakeEnum.withName("good_bye") shouldBe SnakeEnum.GoodBye
         SnakeEnum.withName("SHOUT_GOOD_BYE") shouldBe SnakeEnum.ShoutGoodBye
 
+        UpperSnakeEnum.withName("HELLO") shouldBe UpperSnakeEnum.Hello
+        UpperSnakeEnum.withName("GOOD_BYE") shouldBe UpperSnakeEnum.GoodBye
+        UpperSnakeEnum.withName("whispher_good_bye") shouldBe UpperSnakeEnum.WhispherGoodBye
+
+        CapitalSnakeEnum.withName("Hello") shouldBe CapitalSnakeEnum.Hello
+        CapitalSnakeEnum.withName("Good_Bye") shouldBe CapitalSnakeEnum.GoodBye
+        CapitalSnakeEnum.withName("whispher_good_bye") shouldBe CapitalSnakeEnum.WhispherGoodBye
+
+        HyphenEnum.withName("hello") shouldBe HyphenEnum.Hello
+        HyphenEnum.withName("good-bye") shouldBe HyphenEnum.GoodBye
+        HyphenEnum.withName("SHOUT-GOOD-BYE") shouldBe HyphenEnum.ShoutGoodBye
+
+        UpperHyphenEnum.withName("HELLO") shouldBe UpperHyphenEnum.Hello
+        UpperHyphenEnum.withName("GOOD-BYE") shouldBe UpperHyphenEnum.GoodBye
+        UpperHyphenEnum.withName("whispher-good-bye") shouldBe UpperHyphenEnum.WhispherGoodBye
+
+        CapitalHyphenEnum.withName("Hello") shouldBe CapitalHyphenEnum.Hello
+        CapitalHyphenEnum.withName("Good-Bye") shouldBe CapitalHyphenEnum.GoodBye
+        CapitalHyphenEnum.withName("whispher-good-bye") shouldBe CapitalHyphenEnum.WhispherGoodBye
+
+        DotEnum.withName("hello") shouldBe DotEnum.Hello
+        DotEnum.withName("good.bye") shouldBe DotEnum.GoodBye
+        DotEnum.withName("SHOUT.GOOD.BYE") shouldBe DotEnum.ShoutGoodBye
+
+        UpperDotEnum.withName("HELLO") shouldBe UpperDotEnum.Hello
+        UpperDotEnum.withName("GOOD.BYE") shouldBe UpperDotEnum.GoodBye
+        UpperDotEnum.withName("whispher.good.bye") shouldBe UpperDotEnum.WhispherGoodBye
+
+        CapitalDotEnum.withName("Hello") shouldBe CapitalDotEnum.Hello
+        CapitalDotEnum.withName("Good.Bye") shouldBe CapitalDotEnum.GoodBye
+        CapitalDotEnum.withName("whispher.good.bye") shouldBe CapitalDotEnum.WhispherGoodBye
+
+        WordsEnum.withName("hello") shouldBe WordsEnum.Hello
+        WordsEnum.withName("good bye") shouldBe WordsEnum.GoodBye
+        WordsEnum.withName("SHOUT GOOD BYE") shouldBe WordsEnum.ShoutGoodBye
+
+        UpperWordsEnum.withName("HELLO") shouldBe UpperWordsEnum.Hello
+        UpperWordsEnum.withName("GOOD BYE") shouldBe UpperWordsEnum.GoodBye
+        UpperWordsEnum.withName("whispher good bye") shouldBe UpperWordsEnum.WhispherGoodBye
+
+        CapitalWordsEnum.withName("Hello") shouldBe CapitalWordsEnum.Hello
+        CapitalWordsEnum.withName("Good Bye") shouldBe CapitalWordsEnum.GoodBye
+        CapitalWordsEnum.withName("whispher good bye") shouldBe CapitalWordsEnum.WhispherGoodBye
+
+        UpperEnum.withName("HELLO") shouldBe UpperEnum.Hello
+        UpperEnum.withName("GOODBYE") shouldBe UpperEnum.GoodBye
+        UpperEnum.withName("sike") shouldBe UpperEnum.Sike
+
         LowerEnum.withName("hello") shouldBe LowerEnum.Hello
         LowerEnum.withName("goodbye") shouldBe LowerEnum.GoodBye
         LowerEnum.withName("SIKE") shouldBe LowerEnum.Sike

--- a/enumeratum-core/src/test/scala/enumeratum/Models.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/Models.scala
@@ -32,6 +32,150 @@ object SnakeEnum extends Enum[SnakeEnum] {
 
 }
 
+sealed trait UpperSnakeEnum extends EnumEntry with UpperSnakecase
+
+object UpperSnakeEnum extends Enum[UpperSnakeEnum] {
+
+  val values = findValues
+
+  case object Hello           extends UpperSnakeEnum
+  case object GoodBye         extends UpperSnakeEnum
+  case object WhispherGoodBye extends UpperSnakeEnum with Lowercase
+
+}
+
+sealed trait CapitalSnakeEnum extends EnumEntry with CapitalSnakecase
+
+object CapitalSnakeEnum extends Enum[CapitalSnakeEnum] {
+
+  val values = findValues
+
+  case object Hello           extends CapitalSnakeEnum
+  case object GoodBye         extends CapitalSnakeEnum
+  case object WhispherGoodBye extends CapitalSnakeEnum with Lowercase
+
+}
+
+sealed trait HyphenEnum extends EnumEntry with Hyphencase
+
+object HyphenEnum extends Enum[HyphenEnum] {
+
+  val values = findValues
+
+  case object Hello        extends HyphenEnum
+  case object GoodBye      extends HyphenEnum
+  case object ShoutGoodBye extends HyphenEnum with Uppercase
+
+}
+
+sealed trait UpperHyphenEnum extends EnumEntry with UpperHyphencase
+
+object UpperHyphenEnum extends Enum[UpperHyphenEnum] {
+
+  val values = findValues
+
+  case object Hello           extends UpperHyphenEnum
+  case object GoodBye         extends UpperHyphenEnum
+  case object WhispherGoodBye extends UpperHyphenEnum with Lowercase
+
+}
+
+sealed trait CapitalHyphenEnum extends EnumEntry with CapitalHyphencase
+
+object CapitalHyphenEnum extends Enum[CapitalHyphenEnum] {
+
+  val values = findValues
+
+  case object Hello           extends CapitalHyphenEnum
+  case object GoodBye         extends CapitalHyphenEnum
+  case object WhispherGoodBye extends CapitalHyphenEnum with Lowercase
+
+}
+
+sealed trait DotEnum extends EnumEntry with Dotcase
+
+object DotEnum extends Enum[DotEnum] {
+
+  val values = findValues
+
+  case object Hello        extends DotEnum
+  case object GoodBye      extends DotEnum
+  case object ShoutGoodBye extends DotEnum with Uppercase
+
+}
+
+sealed trait UpperDotEnum extends EnumEntry with UpperDotcase
+
+object UpperDotEnum extends Enum[UpperDotEnum] {
+
+  val values = findValues
+
+  case object Hello           extends UpperDotEnum
+  case object GoodBye         extends UpperDotEnum
+  case object WhispherGoodBye extends UpperDotEnum with Lowercase
+
+}
+
+sealed trait CapitalDotEnum extends EnumEntry with CapitalDotcase
+
+object CapitalDotEnum extends Enum[CapitalDotEnum] {
+
+  val values = findValues
+
+  case object Hello           extends CapitalDotEnum
+  case object GoodBye         extends CapitalDotEnum
+  case object WhispherGoodBye extends CapitalDotEnum with Lowercase
+
+}
+
+sealed trait WordsEnum extends EnumEntry with Words
+
+object WordsEnum extends Enum[WordsEnum] {
+
+  val values = findValues
+
+  case object Hello        extends WordsEnum
+  case object GoodBye      extends WordsEnum
+  case object ShoutGoodBye extends WordsEnum with Uppercase
+
+}
+
+sealed trait UpperWordsEnum extends EnumEntry with UpperWords
+
+object UpperWordsEnum extends Enum[UpperWordsEnum] {
+
+  val values = findValues
+
+  case object Hello           extends UpperWordsEnum
+  case object GoodBye         extends UpperWordsEnum
+  case object WhispherGoodBye extends UpperWordsEnum with Lowercase
+
+}
+
+sealed trait CapitalWordsEnum extends EnumEntry with CapitalWords
+
+object CapitalWordsEnum extends Enum[CapitalWordsEnum] {
+
+  val values = findValues
+
+  case object Hello           extends CapitalWordsEnum
+  case object GoodBye         extends CapitalWordsEnum
+  case object WhispherGoodBye extends CapitalWordsEnum with Lowercase
+
+}
+
+sealed trait UpperEnum extends EnumEntry with Uppercase
+
+object UpperEnum extends Enum[UpperEnum] {
+
+  val values = findValues
+
+  case object Hello   extends UpperEnum
+  case object GoodBye extends UpperEnum
+  case object Sike    extends UpperEnum with Lowercase
+
+}
+
 sealed trait LowerEnum extends EnumEntry with Lowercase
 
 object LowerEnum extends Enum[LowerEnum] {


### PR DESCRIPTION
Previously, I was defining enum types as sealed case objects and overriding `toString` to get the correct formatting when required. For example, instead of the string `"CarModel"`, I wanted `toString` to give `"Car Model"`. `Enumeratum` has limited ability to override the name behaviour, unfortunately, splitting PascalCase to words is not provided.

In this pull request, the stackable traits `UpperSnakecase`, `CapitalSnakecase`, `Hyphencase`, `UpperHyphencase`, `CapitalHyphencase`, `Dotcase`, `UpperDotcase`, `CapitalDotcase`, `Words`, `UpperWords` and `CapitalWords` are provided. This greatly expands `Enumeratum`'s capacity to override name behaviour.