### PR TITLE
Closes #105: Optimise entryName in stackable traits

### DIFF
--- a/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
@@ -18,7 +18,9 @@ abstract class EnumEntry {
     *
     * Override in your implementation if needed
     */
-  def entryName: String = toString
+  def entryName: String = stableEntryName
+
+  private[this] lazy val stableEntryName: String = toString
 
 }
 
@@ -29,9 +31,9 @@ object EnumEntry {
    *
    * http://stackoverflow.com/a/19832063/1814775
    */
-  private val regexp1     = Pattern.compile("([A-Z]+)([A-Z][a-z])")
-  private val regexp2     = Pattern.compile("([a-z\\d])([A-Z])")
-  private val replacement = "$1_$2"
+  private val regexp1: Pattern    = Pattern.compile("([A-Z]+)([A-Z][a-z])")
+  private val regexp2: Pattern    = Pattern.compile("([a-z\\d])([A-Z])")
+  private val replacement: String = "$1_$2"
 
   // Adapted from Lift's StringHelpers#snakify https://github.com/lift/framework/blob/a3075e0676d60861425281427aa5f57c02c3b0bc/core/util/src/main/scala/net/liftweb/util/StringHelpers.scala#L91
   private def camel2WordArray(name: String) = {
@@ -39,50 +41,60 @@ object EnumEntry {
     regexp2.matcher(first).replaceAll(replacement).split("_")
   }
 
+  /*
+    A bunch of helpful traits for manipulating entry names with minimial boilerplate.
+
+    Note that each override is followed by a lazy val that holds the name. This is an optimisation
+    that has been shown to improve speeds by several hundred times when calling entryName
+    (1499.862ns/call before vs 3.180ns/call for something like UpperHyphencase).
+   */
+
   /**
     * Stackable trait to convert the entryName to Capital_Snake_Case .
     */
   trait CapitalSnakecase extends EnumEntry {
-    abstract override def entryName: String =
-      camel2WordArray(super.entryName).mkString("_")
+    override def entryName: String                 = stableEntryName
+    private[this] lazy val stableEntryName: String = camel2WordArray(super.entryName).mkString("_")
   }
 
   /**
     * Stackable trait to convert the entryName to Capital-Hyphen-Case.
     */
   trait CapitalHyphencase extends EnumEntry {
-    abstract override def entryName: String =
-      camel2WordArray(super.entryName).mkString("-")
+    override def entryName: String                 = stableEntryName
+    private[this] lazy val stableEntryName: String = camel2WordArray(super.entryName).mkString("-")
   }
 
   /**
     * Stackable trait to convert the entryName to Capital.Dot.Case.
     */
   trait CapitalDotcase extends EnumEntry {
-    abstract override def entryName: String =
-      camel2WordArray(super.entryName).mkString(".")
+    override def entryName: String                 = stableEntryName
+    private[this] lazy val stableEntryName: String = camel2WordArray(super.entryName).mkString(".")
   }
 
   /**
     * Stackable trait to convert the entryName to Capital Words.
     */
   trait CapitalWords extends EnumEntry {
-    abstract override def entryName: String =
-      camel2WordArray(super.entryName).mkString(" ")
+    override def entryName: String                 = stableEntryName
+    private[this] lazy val stableEntryName: String = camel2WordArray(super.entryName).mkString(" ")
   }
 
   /**
     * Stackable trait to convert the entryName to UPPERCASE.
     */
   trait Uppercase extends EnumEntry {
-    abstract override def entryName: String = super.entryName.toUpperCase
+    override def entryName: String                 = stableEntryName
+    private[this] lazy val stableEntryName: String = super.entryName.toUpperCase
   }
 
   /**
     * Stackable trait to convert the entryName to lowercase.
     */
   trait Lowercase extends EnumEntry {
-    abstract override def entryName: String = super.entryName.toLowerCase
+    override def entryName: String                 = stableEntryName
+    private[this] lazy val stableEntryName: String = super.entryName.toLowerCase
   }
 
   /**


### PR DESCRIPTION
Instead of using abstract override, just override and refer to a stable
private lazy val that refers to super.entryName. Lazy is used because
we don't want to create and store the String if users don't need to
serialise their enums.

Performance comparison (spoiler, in stacked case ~500x faster)

```
Before:
[info] Benchmark                         Mode  Cnt     Score    Error  Units
[info] EnumBenchmarks.entryNameStacked   avgt   30  1499.862 ± 34.588  ns/op
[info] EnumBenchmarks.entryNameStandard  avgt   30     4.461 ±  0.087  ns/op

After:
[info] Benchmark                         Mode  Cnt  Score   Error  Units
[info] EnumBenchmarks.entryNameStacked   avgt   30  3.180 ± 0.040  ns/op
[info] EnumBenchmarks.entryNameStandard  avgt   30  3.185 ± 0.075  ns/op
```