### PR TITLE
Improve the error message thrown when a companion object cannot be found

### DIFF
--- a/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
@@ -414,15 +414,19 @@ class EnumSpec extends FunSpec with Matchers {
 
   describe("materializeEnum") {
     import DummyEnum._
+    def findEnum[A <: EnumEntry: Enum](v: A) = implicitly[Enum[A]]
 
     it("should return the proper Enum object") {
-      def findEnum[A <: EnumEntry: Enum](v: A) = implicitly[Enum[A]]
-
       val hello: DummyEnum = Hello
       val companion        = findEnum(hello)
       companion shouldBe DummyEnum
       companion.values should contain(Hello)
+    }
 
+    it("should fail to compile when passed a singleton object") {
+      """
+        | findEnum(Hello)
+      """ shouldNot compile
     }
   }
 }

--- a/macros/src/main/scala/enumeratum/EnumMacros.scala
+++ b/macros/src/main/scala/enumeratum/EnumMacros.scala
@@ -43,8 +43,8 @@ object EnumMacros {
            |  sealed abstract class Light extends EnumEntry
            |  case object Light extends Enum[Light] {
            |    val values = findValues
-           |    case object Red extends Light
-           |    case object Blue extends Light
+           |    case object Red   extends Light
+           |    case object Blue  extends Light
            |    case object Green extends Light
            |  }
            |

--- a/macros/src/main/scala/enumeratum/EnumMacros.scala
+++ b/macros/src/main/scala/enumeratum/EnumMacros.scala
@@ -1,6 +1,7 @@
 package enumeratum
 
 import ContextUtils.Context
+
 import scala.collection.immutable._
 import scala.util.control.NonFatal
 
@@ -22,8 +23,24 @@ object EnumMacros {
     */
   def materializeEnumImpl[A: c.WeakTypeTag](c: Context) = {
     import c.universe._
-    val symbol = weakTypeOf[A].typeSymbol
-    c.Expr[A](Ident(ContextUtils.companion(c)(symbol)))
+    val symbol          = weakTypeOf[A].typeSymbol
+    val companionSymbol = ContextUtils.companion(c)(symbol)
+    if (companionSymbol == NoSymbol) {
+      c.abort(c.enclosingPosition,
+              s"""
+           |
+           |  Could not find the companion object for type $symbol.
+           |
+           |  If you're sure the companion object exists, you might be able to fix this error by annotating the
+           |  value you're trying to find the companion object for with a parent type (e.g. Light.Red: Light).
+           |
+           |  This error usually happens when trying to find the companion object of a hard-coded enum member, and
+           |  is caused by Scala inferring the type to be the member's single type (e.g. Light.Red.type instead of
+           |  Light).
+         """.stripMargin)
+    } else {
+      c.Expr[A](Ident(companionSymbol))
+    }
   }
 
   /**

--- a/macros/src/main/scala/enumeratum/EnumMacros.scala
+++ b/macros/src/main/scala/enumeratum/EnumMacros.scala
@@ -35,7 +35,7 @@ object EnumMacros {
            |  value you're trying to find the companion object for with a parent type (e.g. Light.Red: Light).
            |
            |  This error usually happens when trying to find the companion object of a hard-coded enum member, and
-           |  is caused by Scala inferring the type to be the member's single type (e.g. Light.Red.type instead of
+           |  is caused by Scala inferring the type to be the member's singleton type (e.g. Light.Red.type instead of
            |  Light).
          """.stripMargin)
     } else {

--- a/macros/src/main/scala/enumeratum/EnumMacros.scala
+++ b/macros/src/main/scala/enumeratum/EnumMacros.scala
@@ -37,6 +37,23 @@ object EnumMacros {
            |  This error usually happens when trying to find the companion object of a hard-coded enum member, and
            |  is caused by Scala inferring the type to be the member's singleton type (e.g. Light.Red.type instead of
            |  Light).
+           |
+           |  To illustrate, given an enum:
+           |
+           |  sealed abstract class Light extends EnumEntry
+           |  case object Light extends Enum[Light] {
+           |    val values = findValues
+           |    case object Red extends Light
+           |    case object Blue extends Light
+           |    case object Green extends Light
+           |  }
+           |
+           |  and a method:
+           |
+           |  def indexOf[A <: EnumEntry: Enum](entry: A): Int = implicitly[Enum[A]].indexOf(entry)
+           |
+           |  Instead of calling like so: indexOf(Light.Red)
+           |                Call like so: indexOf(Light.Red: Light)
          """.stripMargin)
     } else {
       c.Expr[A](Ident(companionSymbol))


### PR DESCRIPTION
Instead of letting the compiler fail with a NoSymbol error, try to catch
it during compilation and offer up a more informative error message.