### PR TITLE
Release/macros 1.5.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,7 @@ lazy val macros = crossProject
                                includeTestSrcs = false): _*)
   .settings(
     name := "enumeratum-macros",
-    version := Versions.Macros.stable,
+    version := Versions.Macros.head,
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value
     )

--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,7 @@ lazy val macros = crossProject
                                includeTestSrcs = false): _*)
   .settings(
     name := "enumeratum-macros",
-    version := Versions.Macros.head,
+    version := Versions.Macros.stable,
     libraryDependencies ++= Seq(
       "org.scala-lang" % "scala-reflect" % scalaVersion.value
     )

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -6,8 +6,8 @@ object Versions {
   }
 
   object Macros {
-    val stable = "1.5.6"
-    val head   = "1.5.7-SNAPSHOT"
+    val stable = "1.5.7"
+    val head   = "1.5.8-SNAPSHOT"
   }
 
 }


### PR DESCRIPTION
Core and libs will be bumped to use the newer version when there is something more significant (fix or feature).

This mostly just improves an error message.