### PR TITLE
Enum Set and Map comparisons

### DIFF
--- a/benchmarking/src/main/java/testing/JAgeGroup.java
+++ b/benchmarking/src/main/java/testing/JAgeGroup.java
@@ -1,0 +1,14 @@
+package testing;
+
+/**
+ * Created by Lloyd on 2/6/17.
+ * <p>
+ * Copyright 2017
+ */
+public enum JAgeGroup {
+    Baby,
+    Toddler,
+    Teenager,
+    Adult,
+    Senior
+}

--- a/benchmarking/src/main/scala/enumeratum/MapComparisons.scala
+++ b/benchmarking/src/main/scala/enumeratum/MapComparisons.scala
@@ -1,0 +1,59 @@
+package enumeratum
+
+import java.util
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+import testing.JAgeGroup
+
+/**
+  * Created by Lloyd on 2/6/17.
+  *
+  * Copyright 2017
+  */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@SuppressWarnings(Array("org.wartremover.warts.Var"))
+class MapComparisons {
+
+  private val jEnumEnumMap = {
+    val m: util.EnumMap[JAgeGroup, String] = new util.EnumMap(classOf[JAgeGroup])
+    JAgeGroup.values().foreach(e => m.put(e, e.name()))
+    m
+  }
+
+  private val jEnumScalaMap = Map(JAgeGroup.values().map(e => e -> e.name()): _*)
+
+  private val ageGroupScalaMap = Map(AgeGroup.values.map(e => e -> e.entryName): _*)
+
+  private def randomFrom[A](seq: Seq[A]): A = {
+    seq(scala.util.Random.nextInt(seq.size))
+  }
+
+  private var jEnum: JAgeGroup       = _
+  private var ageGroupEnum: AgeGroup = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    jEnum = randomFrom(JAgeGroup.values())
+    ageGroupEnum = randomFrom(AgeGroup.values)
+  }
+
+  @Benchmark
+  def jEnumEnumMapGet(bh: Blackhole): Unit = bh.consume {
+    jEnumEnumMap.get(jEnum)
+  }
+
+  @Benchmark
+  def jEnumScalaMapGet(bh: Blackhole): Unit = bh.consume {
+    jEnumScalaMap.get(jEnum)
+  }
+
+  @Benchmark
+  def enumeratumScalaMapGet(bh: Blackhole): Unit = bh.consume {
+    ageGroupScalaMap.get(ageGroupEnum)
+  }
+
+}

--- a/benchmarking/src/main/scala/enumeratum/SetComparisons.scala
+++ b/benchmarking/src/main/scala/enumeratum/SetComparisons.scala
@@ -1,0 +1,57 @@
+package enumeratum
+
+import java.util
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+import testing._
+
+/**
+  * Created by Lloyd on 2/6/17.
+  *
+  * Copyright 2017
+  */
+/**
+  * Compares performance of Java's EnumSet, Scala's Set for JavaEnums and Enumeratum Enums
+  */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@SuppressWarnings(Array("org.wartremover.warts.Var"))
+class SetComparisons {
+
+  private val jEnumEnumSet  = util.EnumSet.allOf(classOf[JAgeGroup])
+  private val jEnumScalaSet = Set(JAgeGroup.values(): _*)
+
+  private val tinyAlphabetEnumScalaSet = Set(AgeGroup.values: _*)
+
+  private def randomFrom[A](seq: Seq[A]): A = {
+    seq(scala.util.Random.nextInt(seq.size))
+  }
+
+  private var jAgeGroupEnum: JAgeGroup = _
+  private var ageGroupEnum: AgeGroup   = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    jAgeGroupEnum = randomFrom(JAgeGroup.values())
+    ageGroupEnum = randomFrom(AgeGroup.values)
+  }
+
+  @Benchmark
+  def jEnumEnumSetContains(bh: Blackhole): Unit = bh.consume {
+    jEnumEnumSet.contains(jAgeGroupEnum)
+  }
+
+  @Benchmark
+  def jEnumScalaSetContains(bh: Blackhole): Unit = bh.consume {
+    jEnumScalaSet.contains(jAgeGroupEnum)
+  }
+
+  @Benchmark
+  def enumeratumScalaSetContains(bh: Blackhole): Unit = bh.consume {
+    tinyAlphabetEnumScalaSet.contains(ageGroupEnum)
+  }
+
+}


### PR DESCRIPTION
- Add comparisons for Java EnumSet and Scala Set
- Add Map comparisons

Results
-------

```
[info] Benchmark                                  Mode  Cnt   Score   Error  Units
[info] MapComparisons.enumeratumScalaMapGet       avgt   30   9.830 ± 0.207  ns/op
[info] MapComparisons.jEnumEnumMapGet             avgt   30   4.745 ± 0.685  ns/op
[info] MapComparisons.jEnumScalaMapGet            avgt   30  12.204 ± 0.186  ns/op
[info] SetComparisons.enumeratumScalaSetContains  avgt   30   7.670 ± 1.333  ns/op
[info] SetComparisons.jEnumEnumSetContains        avgt   30   4.391 ± 0.077  ns/op
[info] SetComparisons.jEnumScalaSetContains       avgt   30   8.906 ± 0.235  ns/op
```

Discussion
----------

There is no denying that Java  EnumMap and EnumSet are fast. Given that JMH supposedly has
an over head of 2-3ns, they both offer roughly 2-3ns/op, which might just be noise !

On the other hand, plain old Scala Set and Map aren't bad either, coming in at < 10ns/op,
which is maybe 4-6ns/op accounting for overhead and noise. They don't do as well with Java Enums though; maybe this is because case objects have nicer hashCode implementations? Not sure.

So the current state of things is that Java EnumMap and EnumSet are roughly 2x faster than
plain old Scala Set and Maps w/ Enumeratum, but being that we're still in the sub-10ns
range, it seems reasonable to say that performance here won't be a bottleneck except in super
edge cases.