### PR TITLE
Add containsAll/subSetOf comparisons

### DIFF
--- a/benchmarking/src/main/scala/enumeratum/SetComparisons.scala
+++ b/benchmarking/src/main/scala/enumeratum/SetComparisons.scala
@@ -78,17 +78,17 @@ class SetComparisons {
   }
 
   @Benchmark
-  def enumeratumScalaSetSubsetOffSmall(bh: Blackhole): Unit = bh.consume {
+  def enumeratumScalaSetSubsetOfSmall(bh: Blackhole): Unit = bh.consume {
     enumeratumScalaSmall.subsetOf(enumeratumScalaSet)
   }
 
   @Benchmark
-  def enumeratumScalaSetSubsetOffMedium(bh: Blackhole): Unit = bh.consume {
+  def enumeratumScalaSetSubsetOfMedium(bh: Blackhole): Unit = bh.consume {
     enumeratumScalaMedium.subsetOf(enumeratumScalaSet)
   }
 
   @Benchmark
-  def enumeratumScalaSetSubsetOffAll(bh: Blackhole): Unit = bh.consume {
+  def enumeratumScalaSetSubsetOfAll(bh: Blackhole): Unit = bh.consume {
     enumeratumScalaSet.subsetOf(enumeratumScalaSet)
   }
 

--- a/benchmarking/src/main/scala/enumeratum/SetComparisons.scala
+++ b/benchmarking/src/main/scala/enumeratum/SetComparisons.scala
@@ -21,10 +21,18 @@ import testing._
 @SuppressWarnings(Array("org.wartremover.warts.Var"))
 class SetComparisons {
 
-  private val jEnumEnumSet  = util.EnumSet.allOf(classOf[JAgeGroup])
+  private val jEnumEnumSet = util.EnumSet.allOf(classOf[JAgeGroup])
+
+  private val jEnumEnumsetSmall = util.EnumSet.of(JAgeGroup.Adult)
+  private val jEnumEnumsetMedium =
+    util.EnumSet.of(JAgeGroup.Adult, JAgeGroup.Baby, JAgeGroup.Senior)
+
   private val jEnumScalaSet = Set(JAgeGroup.values(): _*)
 
-  private val tinyAlphabetEnumScalaSet = Set(AgeGroup.values: _*)
+  private val enumeratumScalaSet                  = Set(AgeGroup.values: _*)
+  private val enumeratumScalaSmall: Set[AgeGroup] = Set(AgeGroup.Adult)
+  private val enumeratumScalaMedium: Set[AgeGroup] =
+    Set(AgeGroup.Adult, AgeGroup.Baby, AgeGroup.Senior)
 
   private def randomFrom[A](seq: Seq[A]): A = {
     seq(scala.util.Random.nextInt(seq.size))
@@ -45,13 +53,43 @@ class SetComparisons {
   }
 
   @Benchmark
+  def jEnumEnumSetContainsAllSmall(bh: Blackhole): Unit = bh.consume {
+    jEnumEnumSet.containsAll(jEnumEnumsetSmall)
+  }
+
+  @Benchmark
+  def jEnumEnumSetContainsAllMedium(bh: Blackhole): Unit = bh.consume {
+    jEnumEnumSet.containsAll(jEnumEnumsetMedium)
+  }
+
+  @Benchmark
+  def jEnumEnumSetContainsAllAll(bh: Blackhole): Unit = bh.consume {
+    jEnumEnumSet.containsAll(jEnumEnumSet)
+  }
+
+  @Benchmark
   def jEnumScalaSetContains(bh: Blackhole): Unit = bh.consume {
     jEnumScalaSet.contains(jAgeGroupEnum)
   }
 
   @Benchmark
   def enumeratumScalaSetContains(bh: Blackhole): Unit = bh.consume {
-    tinyAlphabetEnumScalaSet.contains(ageGroupEnum)
+    enumeratumScalaSet.contains(ageGroupEnum)
+  }
+
+  @Benchmark
+  def enumeratumScalaSetSubsetOffSmall(bh: Blackhole): Unit = bh.consume {
+    enumeratumScalaSmall.subsetOf(enumeratumScalaSet)
+  }
+
+  @Benchmark
+  def enumeratumScalaSetSubsetOffMedium(bh: Blackhole): Unit = bh.consume {
+    enumeratumScalaMedium.subsetOf(enumeratumScalaSet)
+  }
+
+  @Benchmark
+  def enumeratumScalaSetSubsetOffAll(bh: Blackhole): Unit = bh.consume {
+    enumeratumScalaSet.subsetOf(enumeratumScalaSet)
   }
 
 }


### PR DESCRIPTION
Results
-------
```
[info] Benchmark                                         Mode  Cnt   Score   Error  Units
[info] SetComparisons.enumeratumScalaSetSubsetOfSmall   avgt   30   9.248 ± 0.109  ns/op
[info] SetComparisons.enumeratumScalaSetSubsetOfMedium  avgt   30  29.358 ± 0.287  ns/op
[info] SetComparisons.enumeratumScalaSetSubsetOfAll     avgt   30   2.469 ± 0.012  ns/op
[info] SetComparisons.jEnumEnumSetContainsAllSmall      avgt   30   3.888 ± 0.953  ns/op
[info] SetComparisons.jEnumEnumSetContainsAllMedium     avgt   30   3.457 ± 0.127  ns/op
[info] SetComparisons.jEnumEnumSetContainsAllAll        avgt   30   3.321 ± 0.827  ns/op
```

Discussion
----------
As expected, we have O(m) for subset checking on a Set of m elements against one of n elements.
Looking at the source code confirms that we are doing a forall check ;) Funnily enough, subset
check when the sets contain exactly the same elements is crazy fast (!), beating out EnumSet.

EnumSet really shines here because of its ability to do a bitwise AND operation, fulfilling its
O(1) promise.

The ability to do a constain time, fast subset check makes it worthwhile to consider a similar
EnumSet for Enumeratum (backed by an bitwise rep of member indices), even if member indices require a hash-lookup to get.