### PR TITLE
Referencing #116 Try making EnumEntry a Trait

### DIFF
--- a/benchmarking/src/main/scala/enumeratum/SetComparisons.scala
+++ b/benchmarking/src/main/scala/enumeratum/SetComparisons.scala
@@ -29,7 +29,7 @@ class SetComparisons {
 
   private val jEnumScalaSet = Set(JAgeGroup.values(): _*)
 
-  private val enumeratumScalaSet                  = Set(AgeGroup.values: _*)
+  private val enumeratumScalaSet = Set(AgeGroup.values: _*)
 
   // Don't reuse the previous set for All because subsetOf optimises w/ referential eq check :p
   private val enumeratumScalaAll                  = Set(AgeGroup.values: _*)

--- a/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
@@ -11,7 +11,7 @@ import java.util.regex.Pattern
   * Mix in the supplied stackable traits to convert the entryName to [[EnumEntry.Snakecase Snakecase]],
   * [[EnumEntry.Uppercase Uppercase]], [[EnumEntry.Lowercase Lowercase]] etc.
   */
-abstract class EnumEntry {
+trait EnumEntry {
 
   /**
     * String representation of this Enum Entry.


### PR DESCRIPTION
For a more detailed look at the why it is currently an abstract class,
take a look at the issue on Github

Performance-wise, there is a consistent, statistically significant
sub-nanosecond difference, but it's not very big.

```
Abstract class
----------------
1st
[info] Benchmark                         Mode  Cnt  Score   Error  Units
[info] EnumBenchmarks.entryNameStacked   avgt   30  3.150 ± 0.023  ns/op
[info] EnumBenchmarks.entryNameStandard  avgt   30  3.121 ± 0.029  ns/op

2nd
[info] Benchmark                         Mode  Cnt  Score   Error  Units
[info] EnumBenchmarks.entryNameStacked   avgt   30  3.173 ± 0.037  ns/op
[info] EnumBenchmarks.entryNameStandard  avgt   30  3.123 ± 0.024  ns/op

3rd
[info] Benchmark                         Mode  Cnt  Score   Error  Units
[info] EnumBenchmarks.entryNameStacked   avgt   30  3.160 ± 0.037  ns/op
[info] EnumBenchmarks.entryNameStandard  avgt   30  3.112 ± 0.037  ns/op

Trait
-----
1st
[info] Benchmark                         Mode  Cnt  Score   Error  Units
[info] EnumBenchmarks.entryNameStacked   avgt   30  3.458 ± 0.091  ns/op
[info] EnumBenchmarks.entryNameStandard  avgt   30  3.428 ± 0.054  ns/op

2nd
[info] Benchmark                         Mode  Cnt  Score   Error  Units
[info] EnumBenchmarks.entryNameStacked   avgt   30  3.311 ± 0.056  ns/op
[info] EnumBenchmarks.entryNameStandard  avgt   30  3.267 ± 0.039  ns/op

3rd
[info] Benchmark                         Mode  Cnt  Score   Error  Units
[info] EnumBenchmarks.entryNameStacked   avgt   30  3.345 ± 0.047  ns/op
[info] EnumBenchmarks.entryNameStandard  avgt   30  3.539 ± 0.093  ns/op
```