### PR TITLE
Implement Json4s CustomKeySerializer

### DIFF
--- a/enumeratum-json4s/src/main/scala/enumeratum/Json4s.scala
+++ b/enumeratum-json4s/src/main/scala/enumeratum/Json4s.scala
@@ -1,6 +1,6 @@
 package enumeratum
 
-import org.json4s.CustomSerializer
+import org.json4s.{CustomSerializer, CustomKeySerializer}
 import org.json4s.JsonAST.JString
 
 @SuppressWarnings(Array("org.wartremover.warts.Any"))
@@ -44,4 +44,43 @@ object Json4s {
           }
       ))
 
+  /**
+    * Returns a Json [[CustomKeySerializer]] for the given Enumeratum enum
+    *
+    * {{{
+    * scala> import enumeratum._
+    * scala> import org.json4s._
+    * scala> import org.json4s.native.Serialization
+    *
+    * scala> sealed trait ShirtSize extends EnumEntry
+    * scala> case object ShirtSize extends Enum[ShirtSize] {
+    *      |  case object Small  extends ShirtSize
+    *      |  case object Medium extends ShirtSize
+    *      |  case object Large  extends ShirtSize
+    *      |  val values = findValues
+    *      | }
+    *
+    * scala> implicit val formats = Serialization.formats(NoTypeHints) + Json4s.keySerializer(ShirtSize)
+    *
+    * scala> val valueMap = ShirtSize.values.zipWithIndex.toMap
+    *
+    * scala> Serialization.write(valueMap)
+    * res0: String = {"Small":0,"Medium":1,"Large":2}
+    *
+    * scala> Serialization.read[Map[ShirtSize,Int]]("""{"Small":0,"Medium":1,"Large":2}""") == valueMap
+    * res1: Boolean = true
+    * }}}
+    *
+    * @param enum the enum you want to generate a Json4s key serialiser for
+    */
+  def keySerializer[A <: EnumEntry: Manifest](enum: Enum[A]): CustomKeySerializer[A] =
+    new CustomKeySerializer[A](
+      _ =>
+        (
+          {
+            case s: String if enum.withNameOption(s).isDefined => enum.withName(s)
+          }, {
+            case x: A => x.entryName
+          }
+      ))
 }


### PR DESCRIPTION
I ran into an issue where an enum was not deserializing in the expected manner using Json4s. After a bit of debugging, it turns out Json4s uses a separate serializer to convert keys.

The `CustomKeySerializer` class is nearly identical to the `CustomSerializer` class, so it creating a new helper was fairly straightforward, once it's need became apparent.