### PR TITLE
Expands macros in ValueEnumMacros

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -97,11 +97,12 @@ lazy val core = crossProject
   .settings(
     name := "enumeratum",
     version := Versions.Core.head,
-    libraryDependencies += "com.beachape" %% "enumeratum-macros" % Versions.Macros.stable
+    crossScalaVersions := scalaVersions
+//    libraryDependencies += "com.beachape" %% "enumeratum-macros" % Versions.Macros.stable
   )
   .settings(testSettings: _*)
   .settings(commonWithPublishSettings: _*)
-//  .dependsOn(macros) // used for testing macros
+  .dependsOn(macros) // used for testing macros
 lazy val coreJS  = core.js
 lazy val coreJVM = core.jvm
 
@@ -114,18 +115,11 @@ lazy val enumeratumTest = crossProject
   .settings(commonWithPublishSettings: _*)
   .settings(
     name := "enumeratum-test",
-    version := Versions.Core.stable,
-    libraryDependencies += {
-      import org.scalajs.sbtplugin._
-      val crossVersion =
-        if (ScalaJSPlugin.autoImport.jsDependencies.?.value.isDefined)
-          ScalaJSCrossVersion.binary
-        else
-          CrossVersion.binary
-      impl.ScalaJSGroupID
-        .withCross("com.beachape", "enumeratum", crossVersion) % Versions.Core.stable
-    }
+    version := Versions.Core.head,
+    crossScalaVersions := scalaVersions,
+    libraryDependencies += "org.spire-math" %% "spire" % "0.13.0"
   )
+  .dependsOn(core)
 lazy val enumeratumTestJs  = enumeratumTest.js
 lazy val enumeratumTestJvm = enumeratumTest.jvm
 
@@ -151,7 +145,7 @@ lazy val enumeratumReactiveMongoBson =
     .settings(testSettings: _*)
     .settings(
       crossScalaVersions := scalaVersions,
-      version := "1.5.13-SNAPSHOT",
+      version := Versions.Core.head,
       libraryDependencies ++= Seq(
         "org.reactivemongo" %% "reactivemongo"   % reactiveMongoVersion,
         "com.beachape"      %% "enumeratum"      % Versions.Core.stable,
@@ -164,7 +158,7 @@ lazy val enumeratumPlayJson = Project(id = "enumeratum-play-json",
                                       settings = commonWithPublishSettings)
   .settings(testSettings: _*)
   .settings(
-    version := s"1.5.13-SNAPSHOT",
+    version := Versions.Core.head,
     crossScalaVersions := scalaVersions,
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play-json"       % thePlayJsonVersion(scalaVersion.value),
@@ -179,7 +173,7 @@ lazy val enumeratumPlay = Project(id = "enumeratum-play",
                                   settings = commonWithPublishSettings)
   .settings(testSettings: _*)
   .settings(
-    version := s"1.5.13-SNAPSHOT",
+    version := Versions.Core.head,
     crossScalaVersions := scalaVersions,
     libraryDependencies ++= Seq(
       "com.typesafe.play" %% "play"            % thePlayVersion(scalaVersion.value),
@@ -198,7 +192,7 @@ lazy val enumeratumUPickle = crossProject
   .settings(testSettings: _*)
   .settings(
     name := "enumeratum-upickle",
-    version := "1.5.12-SNAPSHOT",
+    version := Versions.Core.head,
     libraryDependencies ++= {
       import org.scalajs.sbtplugin._
       val cross = {
@@ -235,7 +229,7 @@ lazy val enumeratumCirce = crossProject
   .settings(testSettings: _*)
   .settings(
     name := "enumeratum-circe",
-    version := "1.5.15-SNAPSHOT",
+    version := Versions.Core.head,
     libraryDependencies ++= {
       import org.scalajs.sbtplugin._
       val cross = {
@@ -262,7 +256,7 @@ lazy val enumeratumArgonaut = crossProject
   .settings(testSettings: _*)
   .settings(
     name := "enumeratum-argonaut",
-    version := "1.5.13-SNAPSHOT",
+    version := Versions.Core.head,
     crossScalaVersions := scalaVersions,
     libraryDependencies ++= {
       import org.scalajs.sbtplugin._
@@ -288,7 +282,7 @@ lazy val enumeratumJson4s =
           settings = commonWithPublishSettings)
     .settings(testSettings: _*)
     .settings(
-      version := "1.5.14-SNAPSHOT",
+      version := Versions.Core.head,
       crossScalaVersions := scalaVersions,
       libraryDependencies ++= Seq(
         "org.json4s"   %% "json4s-core"   % json4sVersion,

--- a/enumeratum-test/src/main/scala/enumeratum/values/MacroEval.scala
+++ b/enumeratum-test/src/main/scala/enumeratum/values/MacroEval.scala
@@ -1,0 +1,14 @@
+package enumeratum.values
+
+sealed abstract class MacroEval(val value: Int) extends IntEnumEntry
+
+case object MacroEval extends IntEnum[MacroEval] {
+  import spire.syntax.literals.radix._
+
+  case object Zero   extends MacroEval(x2"0")
+  case object One    extends MacroEval(x2"1")
+  case object Two    extends MacroEval(x2"10")
+  case object Eleven extends MacroEval(11)
+
+  val values = findValues
+}

--- a/macros/compat/src/main/scala-2.10/enumeratum/ContextUtils.scala
+++ b/macros/compat/src/main/scala-2.10/enumeratum/ContextUtils.scala
@@ -37,4 +37,10 @@ object ContextUtils {
   def constructorName(c: Context): c.universe.TermName = {
     c.universe.nme.CONSTRUCTOR
   }
+
+  def evalTree[ValueType](c: Context)(expr: c.universe.Tree): ValueType = {
+    @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // false positive bug in WartRemover?
+    val evaluated = c.eval(c.Expr[ValueType](expr))
+    evaluated
+  }
 }

--- a/macros/compat/src/main/scala-2.11/enumeratum/ContextUtils.scala
+++ b/macros/compat/src/main/scala-2.11/enumeratum/ContextUtils.scala
@@ -37,4 +37,10 @@ object ContextUtils {
   def constructorName(c: Context): c.universe.TermName = {
     c.universe.termNames.CONSTRUCTOR
   }
+
+  def evalTree[ValueType](c: Context)(expr: c.universe.Tree): ValueType = {
+    @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements")) // false positive bug in WartRemover?
+    val evaluated = c.eval(c.Expr[ValueType](c.untypecheck(c.typecheck(expr))))
+    evaluated
+  }
 }

--- a/macros/src/main/scala/enumeratum/ValueEnumMacros.scala
+++ b/macros/src/main/scala/enumeratum/ValueEnumMacros.scala
@@ -217,6 +217,14 @@ object ValueEnumMacros {
                       c.enclosingPosition,
                       s"${declTree.symbol} has a value with the wrong type: $i:${i.getClass}, instead of ${classTag.runtimeClass}"
                     )
+
+                  case (_, AssignOrNamedArg(Ident(`valueTerm`), expr)) =>
+                    try {
+                      ContextUtils.evalTree(c)(expr)
+                    } catch {
+                      case t: Throwable =>
+                        c.abort(c.enclosingPosition, s"$expr could not be evaluated at compile time as a ${classTag.runtimeClass}.")
+                    }
                 }
               }
             }


### PR DESCRIPTION
I ran into an issue with ValueEnumMacros, I want to write something like this with binary notation. It was important for me to make sure all of them are different and form an enumeration, but seeing the binary values is important. I don't want to write them as base 10 integers.

```scala
sealed abstract class MacroEval(val value: Int) extends IntEnumEntry

case object MacroEval extends IntEnum[MacroEval] {
  import spire.syntax.literals.radix._

  case object Zero   extends MacroEval(x2"0")
  case object One    extends MacroEval(x2"1")
  case object Two    extends MacroEval(x2"10")

  val values = findValues
}
```

The `x2"010101"` notation is done with macros from Spire and expands into a integer at compile time. Except it won't work with Enumeratum as is because the macros for ValueEnum won't evaluate the expression they receive and rather expect a Literal.

I implemented something that seems to not break stuff and work for my use case. I had to mess with the SBT build a bit. I don't understand why the sub projects depend on external binaries and not the code. It would be nice to have some pointer on how to develop on the project.

Anyway, I wanted to post something that works and can be tested. Let me know what you think. Before merging I will revert those changes off course.