### PR TITLE
Fix enumeratum-scalacheck artifact names

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -298,6 +298,7 @@ lazy val enumeratumScalacheck = crossProject
   .settings(commonWithPublishSettings: _*)
   .settings(testSettings: _*)
   .settings(
+    name := "enumeratum-scalacheck",
     version := "1.5.14-SNAPSHOT",
     libraryDependencies ++= {
       import org.scalajs.sbtplugin._


### PR DESCRIPTION
I messed up and forgot to explicitly set the `name` property.

This PR fixes that. The way I tested it was:
* run `sbt "scalacheck-aggregate/publishLocal"`
* make sure that `.ivy2/local/com.beachape/enumeratum-scalacheck_2.12/` and `.ivy2/local/com.beachape/enumeratum-scalacheck_sjs0.6_2.12/` got created.

Hopefully I didn't miss anything else...