### PR TITLE
Add enumeratum-quill

### DIFF
--- a/README.md
+++ b/README.md
@@ -894,12 +894,14 @@ case class Shirt(size: ShirtSize)
 
 import io.getquill._
 
-val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+lazy val ctx = new PostgresJdbcContext(SnakeCase, "ctx")
 import ctx._
 
-val sql = ctx.run(query[Shirt].insert(_.size -> lift(ShirtSize.Small: ShirtSize))).string
-assert(sql == "INSERT INTO Shirt (size) VALUES (?)")
+ctx.run(query[Shirt].insert(_.size -> lift(ShirtSize.Small: ShirtSize)))
+
+ctx.run(query[Shirt]).foreach(println)
 ```
+- Note that an explicit cast to the `EnumEntry` trait (eg. `ShirtSize.Small: ShirtSize`) is required when binding hardcoded `EnumEntry`s
 
 #### ValueEnum
 
@@ -922,12 +924,14 @@ case class Shirt(size: ShirtSize)
 
 import io.getquill._
 
-val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+lazy val ctx = new PostgresJdbcContext(SnakeCase, "ctx")
 import ctx._
 
-val sql = ctx.run(query[Shirt].insert(_.size -> lift(ShirtSize.Small: ShirtSize))).string
-assert(sql == "INSERT INTO Shirt (size) VALUES (?)")
+ctx.run(query[Shirt].insert(_.size -> lift(ShirtSize.Small: ShirtSize)))
+
+ctx.run(query[Shirt]).foreach(println)
 ```
+- Note that an explicit cast to the `ValueEnumEntry` abstract class (eg. `ShirtSize.Small: ShirtSize`) is required when binding hardcoded `ValueEnumEntry`s
 
 ## Slick integration
 

--- a/README.md
+++ b/README.md
@@ -932,8 +932,8 @@ ctx.run(query[Shirt].insert(_.size -> lift(ShirtSize.Small: ShirtSize)))
 ctx.run(query[Shirt]).foreach(println)
 ```
 - Note that an explicit cast to the `ValueEnumEntry` abstract class (eg. `ShirtSize.Small: ShirtSize`) is required when binding hardcoded `ValueEnumEntry`s
-- `quill-cassandra` currently does not support `ShortEnum` and `ByteEnum` (see getquill/quill#1009)
-- `quill-orientdb` currently does not support `ByteEnum` (see getquill/quill#1029)
+- `quill-cassandra` currently does not support `ShortEnum` and `ByteEnum` (see [getquill/quill#1009](https://github.com/getquill/quill/issues/1009))
+- `quill-orientdb` currently does not support `ByteEnum` (see [getquill/quill#1029](https://github.com/getquill/quill/issues/1029))
 
 ## Slick integration
 

--- a/README.md
+++ b/README.md
@@ -932,6 +932,8 @@ ctx.run(query[Shirt].insert(_.size -> lift(ShirtSize.Small: ShirtSize)))
 ctx.run(query[Shirt]).foreach(println)
 ```
 - Note that an explicit cast to the `ValueEnumEntry` abstract class (eg. `ShirtSize.Small: ShirtSize`) is required when binding hardcoded `ValueEnumEntry`s
+- `quill-cassandra` currently does not support `ShortEnum` and `ByteEnum` (see getquill/quill#1009)
+- `quill-orientdb` currently does not support `ByteEnum` (see getquill/quill#1029)
 
 ## Slick integration
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Integrations are available for:
 - [Argonaut](http://argonaut.io): JVM and ScalaJS
 - [Json4s](http://json4s.org): JVM only
 - [ScalaCheck](https://www.scalacheck.org): JVM only
+- [Quill](http://getquill.io): JVM and ScalaJS
 
 ### Table of Contents
 
@@ -54,8 +55,9 @@ Integrations are available for:
 10. [Json4s integration](#json4s)
 11. [Slick integration](#slick-integration)
 12. [ScalaCheck](#scalacheck)
-13. [Benchmarking](#benchmarking)
-14. [Publishing](#publishing)
+13. [Quill integration](#quill)
+14. [Benchmarking](#benchmarking)
+15. [Publishing](#publishing)
 
 
 ## Quick start
@@ -846,6 +848,85 @@ Similarly, you can get `Arbitrary` and `Cogen` instances for every `ValueEnum` s
 
 ```scala
 import enumeratum.values.scalacheck._
+```
+
+## Quill
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.beachape/enumeratum-quill_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.beachape/enumeratum-quill_2.11)
+
+### SBT
+
+To use enumeratum with [Quill](http://getquill.io):
+
+```scala
+libraryDependencies ++= Seq(
+    "com.beachape" %% "enumeratum-quill" % enumeratumQuillVersion
+)
+```
+
+To use with ScalaJS:
+
+```scala
+libraryDependencies ++= Seq(
+    "com.beachape" %%% "enumeratum-quill" % enumeratumQuillVersion
+)
+```
+
+### Usage
+
+#### Enum
+
+```scala
+import enumeratum._
+
+sealed trait ShirtSize extends EnumEntry
+
+case object ShirtSize extends Enum[ShirtSize] with QuillEnum[ShirtSize] {
+
+  case object Small  extends ShirtSize
+  case object Medium extends ShirtSize
+  case object Large  extends ShirtSize
+
+  val values = findValues
+
+}
+
+case class Shirt(size: ShirtSize)
+
+import io.getquill._
+
+val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+import ctx._
+
+val sql = ctx.run(query[Shirt].insert(_.size -> lift(ShirtSize.Small: ShirtSize))).string
+assert(sql == "INSERT INTO Shirt (size) VALUES (?)")
+```
+
+#### ValueEnum
+
+```scala
+import enumeratum._
+
+sealed abstract class ShirtSize(val value: Int) extends IntEnumEntry
+
+case object ShirtSize extends IntEnum[ShirtSize] with IntQuillEnum[ShirtSize] {
+
+  case object Small  extends ShirtSize(1)
+  case object Medium extends ShirtSize(2)
+  case object Large  extends ShirtSize(3)
+
+  val values = findValues
+
+}
+
+case class Shirt(size: ShirtSize)
+
+import io.getquill._
+
+val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+import ctx._
+
+val sql = ctx.run(query[Shirt].insert(_.size -> lift(ShirtSize.Small: ShirtSize))).string
+assert(sql == "INSERT INTO Shirt (size) VALUES (?)")
 ```
 
 ## Slick integration

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ lazy val circeVersion         = "0.9.0"
 lazy val uPickleVersion       = "0.4.4"
 lazy val argonautVersion      = "6.2"
 lazy val json4sVersion        = "3.5.1"
+lazy val quillVersion         = "2.3.2"
 
 def thePlayVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
@@ -300,6 +301,33 @@ lazy val enumeratumScalacheck =
         "com.beachape"   %% "enumeratum-test" % Versions.Core.stable % Test
       )
     )
+
+lazy val quillAggregate = aggregateProject("quill", enumeratumQuillJs, enumeratumQuillJvm)
+lazy val enumeratumQuill = crossProject
+  .crossType(CrossType.Pure)
+  .in(file("enumeratum-quill"))
+  .settings(commonWithPublishSettings: _*)
+  .settings(testSettings: _*)
+  .settings(
+    name := "enumeratum-quill",
+    version := "0.1.0-SNAPSHOT",
+    libraryDependencies ++= {
+      import org.scalajs.sbtplugin._
+      val cross = {
+        if (ScalaJSPlugin.autoImport.jsDependencies.?.value.isDefined)
+          ScalaJSCrossVersion.binary
+        else
+          CrossVersion.binary
+      }
+      Seq(
+        impl.ScalaJSGroupID.withCross("io.getquill", "quill-core", cross)  % quillVersion,
+        impl.ScalaJSGroupID.withCross("io.getquill", "quill-sql", cross)   % quillVersion % Test,
+        impl.ScalaJSGroupID.withCross("com.beachape", "enumeratum", cross) % Versions.Core.stable
+      )
+    }
+  )
+lazy val enumeratumQuillJs  = enumeratumQuill.js
+lazy val enumeratumQuillJvm = enumeratumQuill.jvm
 
 lazy val commonSettings = Seq(
   organization := "com.beachape",

--- a/enumeratum-quill/src/main/scala/enumeratum/Quill.scala
+++ b/enumeratum-quill/src/main/scala/enumeratum/Quill.scala
@@ -1,0 +1,15 @@
+package enumeratum
+
+import io.getquill.MappedEncoding
+
+object Quill {
+  /**
+    * Returns an Encoder for the given enum
+    */
+  def encoder[A <: EnumEntry](enum: Enum[A]): MappedEncoding[A, String] = MappedEncoding(_.entryName)
+
+  /**
+    * Returns a Decoder for the given enum
+    */
+  def decoder[A <: EnumEntry](enum: Enum[A]): MappedEncoding[String, A] = MappedEncoding(enum.withName)
+}

--- a/enumeratum-quill/src/main/scala/enumeratum/QuillEnum.scala
+++ b/enumeratum-quill/src/main/scala/enumeratum/QuillEnum.scala
@@ -1,0 +1,45 @@
+package enumeratum
+
+import io.getquill.MappedEncoding
+
+/**
+  * Helper trait that adds implicit Quill encoders and decoders for an [[Enum]]'s members
+  *
+  * Example:
+  *
+  * {{{
+  * scala> import enumeratum._
+  * scala> import io.getquill._
+  *
+  * scala> sealed trait ShirtSize extends EnumEntry
+  * scala> case object ShirtSize extends Enum[ShirtSize] with QuillEnum[ShirtSize] {
+  *      |  case object Small  extends ShirtSize
+  *      |  case object Medium extends ShirtSize
+  *      |  case object Large  extends ShirtSize
+  *      |  val values = findValues
+  *      | }
+  *
+  * scala> case class Shirt(size: ShirtSize)
+  *
+  * scala> val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+  * scala> import ctx._
+  *
+  * scala> val size: ShirtSize = ShirtSize.Small
+  *
+  * scala> ctx.run(query[Shirt].insert(_.size -> lift(size))).string
+  * res0: String = INSERT INTO Shirt (size) VALUES (?)
+  * }}}
+  */
+trait QuillEnum[A <: EnumEntry] { this: Enum[A] =>
+
+  /**
+    * Implicit Encoder for this enum
+    */
+  implicit lazy val enumEncoder: MappedEncoding[A, String] = Quill.encoder(this)
+
+  /**
+    * Implicit Decoder for this enum
+    */
+  implicit lazy val enumDecoder: MappedEncoding[String, A] = Quill.decoder(this)
+
+}

--- a/enumeratum-quill/src/main/scala/enumeratum/values/Quill.scala
+++ b/enumeratum-quill/src/main/scala/enumeratum/values/Quill.scala
@@ -1,0 +1,20 @@
+package enumeratum.values
+
+import io.getquill.MappedEncoding
+
+object Quill {
+
+  /**
+    * Returns an Encoder for the provided ValueEnum
+    */
+  def encoder[ValueType, EntryType <: ValueEnumEntry[ValueType]](
+    enum: ValueEnum[ValueType, EntryType]
+  ): MappedEncoding[EntryType, ValueType] = MappedEncoding(_.value)
+
+  /**
+    * Returns a Decoder for the provided ValueEnum
+    */
+  def decoder[ValueType, EntryType <: ValueEnumEntry[ValueType]](
+    enum: ValueEnum[ValueType, EntryType]
+  ): MappedEncoding[ValueType, EntryType] = MappedEncoding(enum.withValue)
+}

--- a/enumeratum-quill/src/main/scala/enumeratum/values/QuillValueEnum.scala
+++ b/enumeratum-quill/src/main/scala/enumeratum/values/QuillValueEnum.scala
@@ -1,0 +1,82 @@
+package enumeratum.values
+
+import io.getquill.MappedEncoding
+
+sealed trait QuillValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]] {
+  this: ValueEnum[ValueType, EntryType] =>
+
+  /**
+    * Implicit Encoder for this enum
+    */
+  implicit val quillEncoder: MappedEncoding[EntryType, ValueType] = Quill.encoder(this)
+
+  /**
+    * Implicit Decoder for this enum
+    */
+  implicit val quillDecoder: MappedEncoding[ValueType, EntryType] = Quill.decoder(this)
+}
+
+/**
+  * QuillEnum for IntEnumEntry
+  *
+  * {{{
+  * scala> import enumeratum.values._
+  * scala> import io.getquill._
+  *
+  * scala> sealed abstract class ShirtSize(val value:Int) extends IntEnumEntry
+  * scala> case object ShirtSize extends IntEnum[ShirtSize] with IntQuillEnum[ShirtSize] {
+  *      |  case object Small  extends ShirtSize(1)
+  *      |  case object Medium extends ShirtSize(2)
+  *      |  case object Large  extends ShirtSize(3)
+  *      |  val values = findValues
+  *      | }
+  *
+  * scala> case class Shirt(size: ShirtSize)
+  *
+  * scala> val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+  * scala> import ctx._
+  *
+  * scala> val size: ShirtSize = ShirtSize.Small
+  *
+  * scala> ctx.run(query[Shirt].insert(_.size -> lift(size))).string
+  * res0: String = INSERT INTO Shirt (size) VALUES (?)
+  * }}}
+  */
+trait IntQuillEnum[EntryType <: IntEnumEntry] extends QuillValueEnum[Int, EntryType] {
+  this: ValueEnum[Int, EntryType] =>
+}
+
+/**
+  * QuillEnum for LongEnumEntry
+  */
+trait LongQuillEnum[EntryType <: LongEnumEntry] extends QuillValueEnum[Long, EntryType] {
+  this: ValueEnum[Long, EntryType] =>
+}
+
+/**
+  * QuillEnum for ShortEnumEntry
+  */
+trait ShortQuillEnum[EntryType <: ShortEnumEntry] extends QuillValueEnum[Short, EntryType] {
+  this: ValueEnum[Short, EntryType] =>
+}
+
+/**
+  * QuillEnum for StringEnumEntry
+  */
+trait StringQuillEnum[EntryType <: StringEnumEntry] extends QuillValueEnum[String, EntryType] {
+  this: ValueEnum[String, EntryType] =>
+}
+
+/**
+  * QuillEnum for CharEnumEntry
+  */
+trait CharQuillEnum[EntryType <: CharEnumEntry] extends QuillValueEnum[Char, EntryType] {
+  this: ValueEnum[Char, EntryType] =>
+}
+
+/**
+  * QuillEnum for ByteEnumEntry
+  */
+trait ByteQuillEnum[EntryType <: ByteEnumEntry] extends QuillValueEnum[Byte, EntryType] {
+  this: ValueEnum[Byte, EntryType] =>
+}

--- a/enumeratum-quill/src/main/scala/enumeratum/values/QuillValueEnum.scala
+++ b/enumeratum-quill/src/main/scala/enumeratum/values/QuillValueEnum.scala
@@ -2,18 +2,18 @@ package enumeratum.values
 
 import io.getquill.MappedEncoding
 
-sealed trait QuillValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]] {
+sealed trait QuillValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType], QuillType] {
   this: ValueEnum[ValueType, EntryType] =>
 
   /**
     * Implicit Encoder for this enum
     */
-  implicit val quillEncoder: MappedEncoding[EntryType, ValueType] = Quill.encoder(this)
+  implicit val quillEncoder: MappedEncoding[EntryType, QuillType]
 
   /**
     * Implicit Decoder for this enum
     */
-  implicit val quillDecoder: MappedEncoding[ValueType, EntryType] = Quill.decoder(this)
+  implicit val quillDecoder: MappedEncoding[QuillType, EntryType]
 }
 
 /**
@@ -42,41 +42,61 @@ sealed trait QuillValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]] {
   * res0: String = INSERT INTO Shirt (size) VALUES (?)
   * }}}
   */
-trait IntQuillEnum[EntryType <: IntEnumEntry] extends QuillValueEnum[Int, EntryType] {
+trait IntQuillEnum[EntryType <: IntEnumEntry] extends QuillValueEnum[Int, EntryType, Int] {
   this: ValueEnum[Int, EntryType] =>
+  implicit val quillEncoder: MappedEncoding[EntryType, Int] = Quill.encoder(this)
+  implicit val quillDecoder: MappedEncoding[Int, EntryType] = Quill.decoder(this)
 }
 
 /**
   * QuillEnum for LongEnumEntry
   */
-trait LongQuillEnum[EntryType <: LongEnumEntry] extends QuillValueEnum[Long, EntryType] {
+trait LongQuillEnum[EntryType <: LongEnumEntry] extends QuillValueEnum[Long, EntryType, Long] {
   this: ValueEnum[Long, EntryType] =>
+  implicit val quillEncoder: MappedEncoding[EntryType, Long] = Quill.encoder(this)
+  implicit val quillDecoder: MappedEncoding[Long, EntryType] = Quill.decoder(this)
 }
 
 /**
   * QuillEnum for ShortEnumEntry
   */
-trait ShortQuillEnum[EntryType <: ShortEnumEntry] extends QuillValueEnum[Short, EntryType] {
+trait ShortQuillEnum[EntryType <: ShortEnumEntry] extends QuillValueEnum[Short, EntryType, Short] {
   this: ValueEnum[Short, EntryType] =>
+  implicit val quillEncoder: MappedEncoding[EntryType, Short] = Quill.encoder(this)
+  implicit val quillDecoder: MappedEncoding[Short, EntryType] = Quill.decoder(this)
 }
 
 /**
   * QuillEnum for StringEnumEntry
   */
-trait StringQuillEnum[EntryType <: StringEnumEntry] extends QuillValueEnum[String, EntryType] {
+trait StringQuillEnum[EntryType <: StringEnumEntry] extends QuillValueEnum[String, EntryType, String] {
   this: ValueEnum[String, EntryType] =>
+  implicit val quillEncoder: MappedEncoding[EntryType, String] = Quill.encoder(this)
+  implicit val quillDecoder: MappedEncoding[String, EntryType] = Quill.decoder(this)
 }
 
 /**
   * QuillEnum for CharEnumEntry
   */
-trait CharQuillEnum[EntryType <: CharEnumEntry] extends QuillValueEnum[Char, EntryType] {
+trait CharQuillEnum[EntryType <: CharEnumEntry] extends QuillValueEnum[Char, EntryType, String] {
   this: ValueEnum[Char, EntryType] =>
+
+  /**
+    * Because all existing Quill contexts do not have built-in Encoders for Char, convert it to a String instead.
+    */
+  implicit val quillEncoder: MappedEncoding[EntryType, String] = MappedEncoding(enum => String.valueOf(enum.value))
+
+  /**
+    * Because all existing Quill contexts do not have built-in Decoders for Char, convert it from a String instead.
+    */
+  implicit val quillDecoder: MappedEncoding[String, EntryType] = MappedEncoding(str => withValue(str.charAt(0)))
 }
 
 /**
   * QuillEnum for ByteEnumEntry
   */
-trait ByteQuillEnum[EntryType <: ByteEnumEntry] extends QuillValueEnum[Byte, EntryType] {
+trait ByteQuillEnum[EntryType <: ByteEnumEntry] extends QuillValueEnum[Byte, EntryType, Byte] {
   this: ValueEnum[Byte, EntryType] =>
+  implicit val quillEncoder: MappedEncoding[EntryType, Byte] = Quill.encoder(this)
+  implicit val quillDecoder: MappedEncoding[Byte, EntryType] = Quill.decoder(this)
 }

--- a/enumeratum-quill/src/test/scala/enumeratum/QuillEnumSpec.scala
+++ b/enumeratum-quill/src/test/scala/enumeratum/QuillEnumSpec.scala
@@ -6,45 +6,42 @@ import scala.collection.immutable
 
 class QuillEnumSpec extends FunSpec with Matchers {
 
-  describe("to SQL String") {
+  describe("A QuillEnum") {
 
     // we only need to test whether it can compile because Quill will fail compilation if an Encoder is not found
-    it("should compile") {
+    it("should encode to String") {
       """
         | import io.getquill._
         | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
         | import ctx._
-        | ctx.run(query[Shirt].insert(_.size -> lift(ShirtSize.Small: ShirtSize)))
+        | ctx.run(query[QuillShirt].insert(_.size -> lift(QuillShirtSize.Small: QuillShirtSize)))
       """.stripMargin should compile
     }
-
-  }
-
-  describe("from SQL String") {
 
     // we only need to test whether it can compile because Quill will fail compilation if a Decoder is not found
-    it("should compile") {
+    it("should decode from String") {
       """
         | import io.getquill._
         | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
         | import ctx._
-        | ctx.run(query[Shirt])
+        | ctx.run(query[QuillShirt])
       """.stripMargin should compile
     }
 
   }
-}
-
-sealed trait ShirtSize extends EnumEntry
-
-case object ShirtSize extends Enum[ShirtSize] with QuillEnum[ShirtSize] {
-
-  case object Small  extends ShirtSize
-  case object Medium extends ShirtSize
-  case object Large  extends ShirtSize
-
-  override val values: immutable.IndexedSeq[ShirtSize] = findValues
 
 }
 
-case class Shirt(size: ShirtSize)
+sealed trait QuillShirtSize extends EnumEntry
+
+case object QuillShirtSize extends Enum[QuillShirtSize] with QuillEnum[QuillShirtSize] {
+
+  case object Small  extends QuillShirtSize
+  case object Medium extends QuillShirtSize
+  case object Large  extends QuillShirtSize
+
+  override val values: immutable.IndexedSeq[QuillShirtSize] = findValues
+
+}
+
+case class QuillShirt(size: QuillShirtSize)

--- a/enumeratum-quill/src/test/scala/enumeratum/QuillEnumSpec.scala
+++ b/enumeratum-quill/src/test/scala/enumeratum/QuillEnumSpec.scala
@@ -1,0 +1,50 @@
+package enumeratum
+
+import org.scalatest.{FunSpec, Matchers}
+
+import scala.collection.immutable
+
+class QuillEnumSpec extends FunSpec with Matchers {
+
+  describe("to SQL String") {
+
+    // we only need to test whether it can compile because Quill will fail compilation if an Encoder is not found
+    it("should compile") {
+      """
+        | import io.getquill._
+        | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+        | import ctx._
+        | ctx.run(query[Shirt].insert(_.size -> lift(ShirtSize.Small: ShirtSize)))
+      """.stripMargin should compile
+    }
+
+  }
+
+  describe("from SQL String") {
+
+    // we only need to test whether it can compile because Quill will fail compilation if a Decoder is not found
+    it("should compile") {
+      """
+        | import io.getquill._
+        | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+        | import ctx._
+        | ctx.run(query[Shirt])
+      """.stripMargin should compile
+    }
+
+  }
+}
+
+sealed trait ShirtSize extends EnumEntry
+
+case object ShirtSize extends Enum[ShirtSize] with QuillEnum[ShirtSize] {
+
+  case object Small  extends ShirtSize
+  case object Medium extends ShirtSize
+  case object Large  extends ShirtSize
+
+  override val values: immutable.IndexedSeq[ShirtSize] = findValues
+
+}
+
+case class Shirt(size: ShirtSize)

--- a/enumeratum-quill/src/test/scala/enumeratum/values/QuillValueEnumSpec.scala
+++ b/enumeratum-quill/src/test/scala/enumeratum/values/QuillValueEnumSpec.scala
@@ -30,6 +30,126 @@ class QuillValueEnumSpec extends FunSpec with Matchers {
 
   }
 
+  describe("A LongQuillEnum") {
+
+    it("should encode to Long") {
+      // we only need to test whether it can compile because Quill will fail compilation if an Encoder is not found
+      """
+        | import io.getquill._
+        | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+        | import ctx._
+        | ctx.run(query[QuillContent].insert(_.`type` -> lift(QuillContentType.Image: QuillContentType)))
+      """.stripMargin should compile
+    }
+
+    it("should decode from Long") {
+      // we only need to test whether it can compile because Quill will fail compilation if a Decoder is not found
+      """
+        | import io.getquill._
+        | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+        | import ctx._
+        | ctx.run(query[QuillContent])
+      """.stripMargin should compile
+    }
+
+  }
+
+  describe("A ShortQuillEnum") {
+
+    it("should encode to Short") {
+      // we only need to test whether it can compile because Quill will fail compilation if an Encoder is not found
+      """
+        | import io.getquill._
+        | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+        | import ctx._
+        | ctx.run(query[QuillDrinkManufacturer].insert(_.name -> "Coca-Cola", _.drink -> lift(QuillDrink.Cola: QuillDrink)))
+      """.stripMargin should compile
+    }
+
+    it("should decode from Short") {
+      // we only need to test whether it can compile because Quill will fail compilation if a Decoder is not found
+      """
+        | import io.getquill._
+        | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+        | import ctx._
+        | ctx.run(query[QuillDrinkManufacturer])
+      """.stripMargin should compile
+    }
+
+  }
+
+  describe("A StringQuillEnum") {
+
+    it("should encode to String") {
+      // we only need to test whether it can compile because Quill will fail compilation if an Encoder is not found
+      """
+        | import io.getquill._
+        | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+        | import ctx._
+        | ctx.run(query[QuillComputer].insert(_.operatingSystem -> lift(QuillOperatingSystem.Windows: QuillOperatingSystem)))
+      """.stripMargin should compile
+    }
+
+    it("should decode from String") {
+      // we only need to test whether it can compile because Quill will fail compilation if a Decoder is not found
+      """
+        | import io.getquill._
+        | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+        | import ctx._
+        | ctx.run(query[QuillComputer])
+      """.stripMargin should compile
+    }
+
+  }
+
+  describe("A CharQuillEnum") {
+
+    it("should encode to Char") {
+      // we only need to test whether it can compile because Quill will fail compilation if an Encoder is not found
+      """
+        | import io.getquill._
+        | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+        | import ctx._
+        | ctx.run(query[QuillName].insert(_.name -> "Daniel", _.initials -> lift(QuillAlphabet.D: QuillAlphabet)))
+      """.stripMargin should compile
+    }
+
+    it("should decode from Char") {
+      // we only need to test whether it can compile because Quill will fail compilation if a Decoder is not found
+      """
+        | import io.getquill._
+        | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+        | import ctx._
+        | ctx.run(query[QuillName])
+      """.stripMargin should compile
+    }
+
+  }
+
+  describe("A ByteQuillEnum") {
+
+    it("should encode to Byte") {
+      // we only need to test whether it can compile because Quill will fail compilation if an Encoder is not found
+      """
+        | import io.getquill._
+        | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+        | import ctx._
+        | ctx.run(query[QuillChar].insert(_.byte1 -> lift(QuillByte.ThreeByte: QuillByte), _.byte2 -> lift(QuillByte.TwoByte: QuillByte)))
+      """.stripMargin should compile
+    }
+
+    it("should decode from Byte") {
+      // we only need to test whether it can compile because Quill will fail compilation if a Decoder is not found
+      """
+        | import io.getquill._
+        | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+        | import ctx._
+        | ctx.run(query[QuillChar])
+      """.stripMargin should compile
+    }
+
+  }
+
 }
 
 sealed abstract class QuillLibraryItem(val value: Int, val name: String) extends IntEnumEntry
@@ -49,3 +169,80 @@ case object QuillLibraryItem
 }
 
 case class QuillBorrowerToLibraryItem(borrower: String, item: QuillLibraryItem)
+
+sealed abstract class QuillContentType(val value: Long, name: String) extends LongEnumEntry
+
+case object QuillContentType
+  extends LongEnum[QuillContentType]
+    with LongQuillEnum[QuillContentType] {
+
+  override val values: immutable.IndexedSeq[QuillContentType] = findValues
+
+  case object Text  extends QuillContentType(value = 1L, name = "text")
+  case object Image extends QuillContentType(value = 2L, name = "image")
+  case object Video extends QuillContentType(value = 3L, name = "video")
+  case object Audio extends QuillContentType(value = 4L, name = "audio")
+
+}
+
+case class QuillContent(`type`: QuillContentType)
+
+sealed abstract class QuillDrink(val value: Short, name: String) extends ShortEnumEntry
+
+case object QuillDrink extends ShortEnum[QuillDrink] with ShortQuillEnum[QuillDrink] {
+
+  case object OrangeJuice extends QuillDrink(value = 1, name = "oj")
+  case object AppleJuice  extends QuillDrink(value = 2, name = "aj")
+  case object Cola        extends QuillDrink(value = 3, name = "cola")
+  case object Beer        extends QuillDrink(value = 4, name = "beer")
+
+  override val values: immutable.IndexedSeq[QuillDrink] = findValues
+
+}
+
+case class QuillDrinkManufacturer(name: String, drink: QuillDrink)
+
+sealed abstract class QuillOperatingSystem(val value: String) extends StringEnumEntry
+
+case object QuillOperatingSystem
+  extends StringEnum[QuillOperatingSystem]
+    with StringQuillEnum[QuillOperatingSystem] {
+
+  case object Linux   extends QuillOperatingSystem("linux")
+  case object OSX     extends QuillOperatingSystem("osx")
+  case object Windows extends QuillOperatingSystem("windows")
+  case object Android extends QuillOperatingSystem("android")
+
+  override val values: immutable.IndexedSeq[QuillOperatingSystem] = findValues
+
+}
+
+case class QuillComputer(operatingSystem: QuillOperatingSystem)
+
+sealed abstract class QuillAlphabet(val value: Char) extends CharEnumEntry
+
+case object QuillAlphabet extends CharEnum[QuillAlphabet] with CharQuillEnum[QuillAlphabet] {
+
+  case object A extends QuillAlphabet('A')
+  case object B extends QuillAlphabet('B')
+  case object C extends QuillAlphabet('C')
+  case object D extends QuillAlphabet('D')
+
+  override val values: immutable.IndexedSeq[QuillAlphabet] = findValues
+
+}
+
+case class QuillName(name: String, initials: QuillAlphabet)
+
+sealed abstract class QuillByte(val value: Byte) extends ByteEnumEntry
+
+object QuillByte extends ByteEnum[QuillByte] with ByteQuillEnum[QuillByte] {
+  override val values: immutable.IndexedSeq[QuillByte] = findValues
+
+  case object OneByte   extends QuillByte(1)
+  case object TwoByte   extends QuillByte(2)
+  case object ThreeByte extends QuillByte(3)
+  case object FourByte  extends QuillByte(4)
+}
+
+case class QuillChar(byte1: QuillByte, byte2: QuillByte)

--- a/enumeratum-quill/src/test/scala/enumeratum/values/QuillValueEnumSpec.scala
+++ b/enumeratum-quill/src/test/scala/enumeratum/values/QuillValueEnumSpec.scala
@@ -1,0 +1,50 @@
+package enumeratum.values
+
+import org.scalatest.{FunSpec, Matchers}
+
+import scala.collection.immutable
+
+class QuillValueEnumSpec extends FunSpec with Matchers {
+
+  describe("to SQL String") {
+
+    // we only need to test whether it can compile because Quill will fail compilation if an Encoder is not found
+    it("should compile") {
+      """
+        | import io.getquill._
+        | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+        | import ctx._
+        | ctx.run(query[Shirt].insert(_.size -> lift(ShirtSize.Small: ShirtSize)))
+      """.stripMargin should compile
+    }
+
+  }
+
+  describe("from SQL String") {
+
+    // we only need to test whether it can compile because Quill will fail compilation if a Decoder is not found
+    it("should compile") {
+      """
+        | import io.getquill._
+        | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+        | import ctx._
+        | ctx.run(query[Shirt])
+      """.stripMargin should compile
+    }
+
+  }
+}
+
+sealed abstract class ShirtSize(val value: Int) extends IntEnumEntry
+
+case object ShirtSize extends IntEnum[ShirtSize] with IntQuillEnum[ShirtSize] {
+
+  case object Small  extends ShirtSize(1)
+  case object Medium extends ShirtSize(2)
+  case object Large  extends ShirtSize(3)
+
+  override val values: immutable.IndexedSeq[ShirtSize] = findValues
+
+}
+
+case class Shirt(size: ShirtSize)

--- a/enumeratum-quill/src/test/scala/enumeratum/values/QuillValueEnumSpec.scala
+++ b/enumeratum-quill/src/test/scala/enumeratum/values/QuillValueEnumSpec.scala
@@ -6,45 +6,46 @@ import scala.collection.immutable
 
 class QuillValueEnumSpec extends FunSpec with Matchers {
 
-  describe("to SQL String") {
+  describe("An IntQuillEnum") {
 
-    // we only need to test whether it can compile because Quill will fail compilation if an Encoder is not found
-    it("should compile") {
+    it("should encode to Int") {
+      // we only need to test whether it can compile because Quill will fail compilation if an Encoder is not found
       """
         | import io.getquill._
         | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
         | import ctx._
-        | ctx.run(query[Shirt].insert(_.size -> lift(ShirtSize.Small: ShirtSize)))
+        | ctx.run(query[QuillBorrowerToLibraryItem].insert(_.borrower -> "Foo", _.item -> lift(QuillLibraryItem.Book: QuillLibraryItem)))
+      """.stripMargin should compile
+    }
+
+    it("should decode from Int") {
+      // we only need to test whether it can compile because Quill will fail compilation if a Decoder is not found
+      """
+        | import io.getquill._
+        | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
+        | import ctx._
+        | ctx.run(query[QuillBorrowerToLibraryItem])
       """.stripMargin should compile
     }
 
   }
 
-  describe("from SQL String") {
-
-    // we only need to test whether it can compile because Quill will fail compilation if a Decoder is not found
-    it("should compile") {
-      """
-        | import io.getquill._
-        | val ctx = new SqlMirrorContext(MirrorSqlDialect, Literal)
-        | import ctx._
-        | ctx.run(query[Shirt])
-      """.stripMargin should compile
-    }
-
-  }
 }
 
-sealed abstract class ShirtSize(val value: Int) extends IntEnumEntry
+sealed abstract class QuillLibraryItem(val value: Int, val name: String) extends IntEnumEntry
 
-case object ShirtSize extends IntEnum[ShirtSize] with IntQuillEnum[ShirtSize] {
+case object QuillLibraryItem
+  extends IntEnum[QuillLibraryItem]
+    with IntQuillEnum[QuillLibraryItem] {
 
-  case object Small  extends ShirtSize(1)
-  case object Medium extends ShirtSize(2)
-  case object Large  extends ShirtSize(3)
+  // A good mix of named, unnamed, named + unordered args
+  case object Book     extends QuillLibraryItem(value = 1, name = "book")
+  case object Movie    extends QuillLibraryItem(name = "movie", value = 2)
+  case object Magazine extends QuillLibraryItem(3, "magazine")
+  case object CD       extends QuillLibraryItem(4, name = "cd")
 
-  override val values: immutable.IndexedSeq[ShirtSize] = findValues
+  override val values: immutable.IndexedSeq[QuillLibraryItem] = findValues
 
 }
 
-case class Shirt(size: ShirtSize)
+case class QuillBorrowerToLibraryItem(borrower: String, item: QuillLibraryItem)

--- a/publish-integration-libs
+++ b/publish-integration-libs
@@ -17,4 +17,6 @@ say "Done 6" &&
 sbt "project enumeratum-json4s" +clean +publishSigned &&
 say "Done 7" &&
 sbt "project enumeratum-scalacheck" +clean +publishSigned &&
+say "Done 8" &&
+sbt "project quill-aggregate" +clean +publishSigned &&
 say "All done"


### PR DESCRIPTION
As mentioned in #163.

Adds `QuillEnum` trait to automatically convert `EnumEntry`s to/from their `entryName`.
Adds `QuillValueEnum` trait to automatically convert `ValueEnumEntry`s to/from their `value`s.

I wasn't sure what to put for the `version`, so I left it as `0.1.0-SNAPSHOT`.
