### PR TITLE
Many to one

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -293,7 +293,7 @@ lazy val enumeratumScalacheck =
     .settings(commonWithPublishSettings: _*)
     .settings(testSettings: _*)
     .settings(
-      version := "1.5.13",
+      version := "1.5.14-SNAPSHOT",
       libraryDependencies ++= Seq(
         "org.scalacheck" %% "scalacheck"      % scalacheckVersion,
         "com.beachape"   %% "enumeratum"      % Versions.Core.stable,

--- a/enumeratum-core/src/main/scala/enumeratum/Enum.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/Enum.scala
@@ -3,6 +3,7 @@ package enumeratum
 import scala.language.experimental.macros
 
 import scala.collection.immutable._
+import scala.collection.breakOut
 
 /**
   * All the cool kids have their own Enumeration implementation, most of which try to
@@ -38,20 +39,20 @@ trait Enum[A <: EnumEntry] {
   /**
     * Map of [[A]] object names to [[A]]s
     */
-  lazy final val namesToValuesMap: Map[String, A] =
-    values.map(v => v.entryName -> v).toMap
+  lazy val namesToValuesMap: Map[String, A] =
+    values.map(v => v.entryName -> v)(breakOut)
 
   /**
     * Map of [[A]] object names in lower case to [[A]]s for case-insensitive comparison
     */
   lazy final val lowerCaseNamesToValuesMap: Map[String, A] =
-    values.map(v => v.entryName.toLowerCase -> v).toMap
+    values.map(v => v.entryName.toLowerCase -> v)(breakOut)
 
   /**
     * Map of [[A]] object names in upper case to [[A]]s for case-insensitive comparison
     */
   lazy final val upperCaseNameValuesToMap: Map[String, A] =
-    values.map(v => v.entryName.toUpperCase -> v).toMap
+    values.map(v => v.entryName.toUpperCase -> v)(breakOut)
 
   /**
     * Map of [[A]] to their index in the values sequence.

--- a/enumeratum-core/src/main/scala/enumeratum/Enum.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/Enum.scala
@@ -44,13 +44,13 @@ trait Enum[A <: EnumEntry] {
     * Map of [[A]] object names in lower case to [[A]]s for case-insensitive comparison
     */
   lazy final val lowerCaseNamesToValuesMap: Map[String, A] =
-    values.map(v => v.entryName.toLowerCase -> v).toMap
+    namesToValuesMap.map{ case (k, v) => k.toLowerCase -> v }
 
   /**
     * Map of [[A]] object names in upper case to [[A]]s for case-insensitive comparison
     */
   lazy final val upperCaseNameValuesToMap: Map[String, A] =
-    values.map(v => v.entryName.toUpperCase -> v).toMap
+    namesToValuesMap.map{ case (k, v) => k.toUpperCase() -> v }
 
   /**
     * Map of [[A]] to their index in the values sequence.

--- a/enumeratum-core/src/main/scala/enumeratum/Enum.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/Enum.scala
@@ -1,9 +1,7 @@
 package enumeratum
 
-import scala.language.experimental.macros
-
 import scala.collection.immutable._
-import scala.collection.breakOut
+import scala.language.experimental.macros
 
 /**
   * All the cool kids have their own Enumeration implementation, most of which try to
@@ -40,19 +38,19 @@ trait Enum[A <: EnumEntry] {
     * Map of [[A]] object names to [[A]]s
     */
   lazy val namesToValuesMap: Map[String, A] =
-    values.map(v => v.entryName -> v)(breakOut)
+    values.map(v => v.entryName -> v).toMap
 
   /**
     * Map of [[A]] object names in lower case to [[A]]s for case-insensitive comparison
     */
   lazy final val lowerCaseNamesToValuesMap: Map[String, A] =
-    values.map(v => v.entryName.toLowerCase -> v)(breakOut)
+    values.map(v => v.entryName.toLowerCase -> v).toMap
 
   /**
     * Map of [[A]] object names in upper case to [[A]]s for case-insensitive comparison
     */
   lazy final val upperCaseNameValuesToMap: Map[String, A] =
-    values.map(v => v.entryName.toUpperCase -> v)(breakOut)
+    values.map(v => v.entryName.toUpperCase -> v).toMap
 
   /**
     * Map of [[A]] to their index in the values sequence.

--- a/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
@@ -31,8 +31,8 @@ object EnumEntry {
    *
    * http://stackoverflow.com/a/19832063/1814775
    */
-  private val regexp1: Pattern = Pattern.compile("([A-Z]+)([A-Z][a-z])")
-  private val regexp2: Pattern = Pattern.compile("([a-z\\d])([A-Z])")
+  private val regexp1: Pattern    = Pattern.compile("([A-Z]+)([A-Z][a-z])")
+  private val regexp2: Pattern    = Pattern.compile("([a-z\\d])([A-Z])")
   private val replacement: String = "$1_$2"
 
   // Adapted from Lift's StringHelpers#snakify https://github.com/lift/framework/blob/a3075e0676d60861425281427aa5f57c02c3b0bc/core/util/src/main/scala/net/liftweb/util/StringHelpers.scala#L91
@@ -174,9 +174,6 @@ object EnumEntry {
     * Stackable trait to convert the entryName to lowerCamelCase.
     */
   trait LowerCamelcase extends EnumEntry with Camelcase with Uncapitalised
-
-  abstract class MultiEnum(override val entryName: String,
-                           val alternateNames: String*) extends EnumEntry
 
   /**
     * Helper implicit class that holds enrichment methods

--- a/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
@@ -31,8 +31,8 @@ object EnumEntry {
    *
    * http://stackoverflow.com/a/19832063/1814775
    */
-  private val regexp1: Pattern    = Pattern.compile("([A-Z]+)([A-Z][a-z])")
-  private val regexp2: Pattern    = Pattern.compile("([a-z\\d])([A-Z])")
+  private val regexp1: Pattern = Pattern.compile("([A-Z]+)([A-Z][a-z])")
+  private val regexp2: Pattern = Pattern.compile("([a-z\\d])([A-Z])")
   private val replacement: String = "$1_$2"
 
   // Adapted from Lift's StringHelpers#snakify https://github.com/lift/framework/blob/a3075e0676d60861425281427aa5f57c02c3b0bc/core/util/src/main/scala/net/liftweb/util/StringHelpers.scala#L91
@@ -62,7 +62,8 @@ object EnumEntry {
     * Stackable trait to convert the entryName to Capital_Snake_Case .
     */
   trait CapitalSnakecase extends EnumEntry {
-    override def entryName: String                 = stableEntryName
+    override def entryName: String = stableEntryName
+
     private[this] lazy val stableEntryName: String = camel2WordArray(super.entryName).mkString("_")
   }
 
@@ -70,7 +71,8 @@ object EnumEntry {
     * Stackable trait to convert the entryName to Capital-Hyphen-Case.
     */
   trait CapitalHyphencase extends EnumEntry {
-    override def entryName: String                 = stableEntryName
+    override def entryName: String = stableEntryName
+
     private[this] lazy val stableEntryName: String = camel2WordArray(super.entryName).mkString("-")
   }
 
@@ -78,7 +80,8 @@ object EnumEntry {
     * Stackable trait to convert the entryName to Capital.Dot.Case.
     */
   trait CapitalDotcase extends EnumEntry {
-    override def entryName: String                 = stableEntryName
+    override def entryName: String = stableEntryName
+
     private[this] lazy val stableEntryName: String = camel2WordArray(super.entryName).mkString(".")
   }
 
@@ -86,7 +89,8 @@ object EnumEntry {
     * Stackable trait to convert the entryName to Capital Words.
     */
   trait CapitalWords extends EnumEntry {
-    override def entryName: String                 = stableEntryName
+    override def entryName: String = stableEntryName
+
     private[this] lazy val stableEntryName: String = camel2WordArray(super.entryName).mkString(" ")
   }
 
@@ -94,7 +98,8 @@ object EnumEntry {
     * Stackable trait to convert the entryName to CamelCase.
     */
   trait Camelcase extends EnumEntry {
-    override def entryName: String                 = stableEntryName
+    override def entryName: String = stableEntryName
+
     private[this] lazy val stableEntryName: String = super.entryName.split("_+").map(s => capitalise(s.toLowerCase)).mkString
   }
 
@@ -102,7 +107,8 @@ object EnumEntry {
     * Stackable trait to convert the entryName to UPPERCASE.
     */
   trait Uppercase extends EnumEntry {
-    override def entryName: String                 = stableEntryName
+    override def entryName: String = stableEntryName
+
     private[this] lazy val stableEntryName: String = super.entryName.toUpperCase
   }
 
@@ -110,7 +116,8 @@ object EnumEntry {
     * Stackable trait to convert the entryName to lowercase.
     */
   trait Lowercase extends EnumEntry {
-    override def entryName: String                 = stableEntryName
+    override def entryName: String = stableEntryName
+
     private[this] lazy val stableEntryName: String = super.entryName.toLowerCase
   }
 
@@ -118,7 +125,8 @@ object EnumEntry {
     * Stackable trait to uncapitalise the first letter of the entryName.
     */
   trait Uncapitalised extends EnumEntry {
-    override def entryName: String                 = stableEntryName
+    override def entryName: String = stableEntryName
+
     private[this] lazy val stableEntryName: String = uncapitalise(super.entryName)
   }
 
@@ -166,6 +174,9 @@ object EnumEntry {
     * Stackable trait to convert the entryName to lowerCamelCase.
     */
   trait LowerCamelcase extends EnumEntry with Camelcase with Uncapitalised
+
+  abstract class MultiEnum(override val entryName: String,
+                           val alternateNames: String*) extends EnumEntry
 
   /**
     * Helper implicit class that holds enrichment methods

--- a/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
@@ -320,6 +320,7 @@ class EnumSpec extends FunSpec with Matchers {
 
         MultiEnum.withName("one") shouldBe MultiEnum.One
         MultiEnum.withName("1") shouldBe MultiEnum.One
+        a [NoSuchElementException] should be thrownBy MultiEnum.withName("One")
         MultiEnum.withName("eins") shouldBe MultiEnum.One
         MultiEnum.withName("two") shouldBe MultiEnum.Two
       }

--- a/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
@@ -318,10 +318,10 @@ class EnumSpec extends FunSpec with Matchers {
         UncapitalisedEnum.withName("SIKE") shouldBe UncapitalisedEnum.Sike
         UncapitalisedEnum.withName("a") shouldBe UncapitalisedEnum.a
 
-        MultiEnum.withName("One") shouldBe MultiEnum.One
+        MultiEnum.withName("one") shouldBe MultiEnum.One
         MultiEnum.withName("1") shouldBe MultiEnum.One
         MultiEnum.withName("eins") shouldBe MultiEnum.One
-        MultiEnum.withName("Two") shouldBe MultiEnum.Two
+        MultiEnum.withName("two") shouldBe MultiEnum.Two
       }
     }
   }

--- a/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
@@ -317,6 +317,11 @@ class EnumSpec extends FunSpec with Matchers {
         UncapitalisedEnum.withName("goodBye") shouldBe UncapitalisedEnum.GoodBye
         UncapitalisedEnum.withName("SIKE") shouldBe UncapitalisedEnum.Sike
         UncapitalisedEnum.withName("a") shouldBe UncapitalisedEnum.a
+
+        MultiEnum.withName("One") shouldBe MultiEnum.One
+        MultiEnum.withName("1") shouldBe MultiEnum.One
+        MultiEnum.withName("eins") shouldBe MultiEnum.One
+        MultiEnum.withName("Two") shouldBe MultiEnum.Two
       }
     }
   }

--- a/enumeratum-core/src/test/scala/enumeratum/Models.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/Models.scala
@@ -236,7 +236,7 @@ case object MultiEnum extends Enum[MultiEnum] {
 
   override lazy val namesToValuesMap: Map[String, MultiEnum] =
     values.flatMap { n =>
-      (n.entryName -> n) +: n.alternateNames.map(name => name -> n)
+      (n.entryName -> n) +: n.alternateNames.map(_ -> n)
     }.toMap
 
   case object One   extends MultiEnum("one", "1", "eins")

--- a/enumeratum-core/src/test/scala/enumeratum/Models.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/Models.scala
@@ -227,14 +227,17 @@ object UncapitalisedEnum extends Enum[UncapitalisedEnum] {
 
 }
 
+sealed class MultiEnum(override val entryName: String,
+                       val alternateNames: String*) extends EnumEntry
+
+
 case object MultiEnum extends Enum[MultiEnum] {
-  import scala.collection.breakOut
   val values = findValues
 
-  override val namesToValuesMap: Map[String, MultiEnum] =
+  override lazy val namesToValuesMap: Map[String, MultiEnum] =
     values.flatMap { n =>
       (n.entryName -> n) +: n.alternateNames.map(name => name -> n)
-    }(breakOut)
+    }.toMap
 
   case object One   extends MultiEnum("one", "1", "eins")
   case object Two   extends MultiEnum("two", "2", "zwei")

--- a/enumeratum-core/src/test/scala/enumeratum/Models.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/Models.scala
@@ -227,6 +227,19 @@ object UncapitalisedEnum extends Enum[UncapitalisedEnum] {
 
 }
 
+case object MultiEnum extends Enum[MultiEnum] {
+  import scala.collection.breakOut
+  val values = findValues
+
+  override val namesToValuesMap: Map[String, MultiEnum] =
+    values.flatMap { n =>
+      (n.entryName -> n) +: n.alternateNames.map(name => name -> n)
+    }(breakOut)
+
+  case object One   extends MultiEnum("one", "1", "eins")
+  case object Two   extends MultiEnum("two", "2", "zwei")
+}
+
 object Wrapper {
 
   sealed trait SmartEnum extends EnumEntry


### PR DESCRIPTION
Adds support for `MultiEnum`, which maps multiple entries to a single enum. Also uses `breakOut` for some minor memory optimization.