### PR TITLE
Circe KeyEncoder/KeyDecoder for String Enum

### DIFF
--- a/enumeratum-circe/src/main/scala/enumeratum/values/Circe.scala
+++ b/enumeratum-circe/src/main/scala/enumeratum/values/Circe.scala
@@ -42,4 +42,15 @@ object Circe {
         }
     }
   }
+
+  def keyEncoder[EntryType <: ValueEnumEntry[String]](
+    enum: ValueEnum[String, EntryType]
+  ): KeyEncoder[EntryType] =
+    KeyEncoder.instance(_.value)
+
+  def keyDecoder[EntryType <: ValueEnumEntry[String]](
+    enum: ValueEnum[String, EntryType]
+  ): KeyDecoder[EntryType] =
+    KeyDecoder.instance(enum.withValueOpt)
+
 }

--- a/enumeratum-circe/src/main/scala/enumeratum/values/CirceValueEnum.scala
+++ b/enumeratum-circe/src/main/scala/enumeratum/values/CirceValueEnum.scala
@@ -1,6 +1,6 @@
 package enumeratum.values
 
-import io.circe.{Decoder, Encoder}
+import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder}
 
 /**
   * Created by Lloyd on 4/14/16.
@@ -81,6 +81,9 @@ trait StringCirceEnum[EntryType <: StringEnumEntry] extends CirceValueEnum[Strin
   this: ValueEnum[String, EntryType] =>
   implicit val circeEncoder: Encoder[EntryType] = Circe.encoder(this)
   implicit val circeDecoder: Decoder[EntryType] = Circe.decoder(this)
+
+  implicit val circeKeyEncoder: KeyEncoder[EntryType] = Circe.keyEncoder(this)
+  implicit val circeKeyDecoder: KeyDecoder[EntryType] = Circe.keyDecoder(this)
 }
 
 /**

--- a/enumeratum-circe/src/test/scala/enumeratum/values/CirceValueEnumSpec.scala
+++ b/enumeratum-circe/src/test/scala/enumeratum/values/CirceValueEnumSpec.scala
@@ -66,7 +66,19 @@ class CirceValueEnumSpec extends FunSpec with Matchers {
     enum: ValueEnum[String, EntryType] with CirceValueEnum[String, EntryType]
   ): Unit = {
     describe(s"$enumKind as Key") {
-      
+      describe("to JSON") {
+        it("should work") {
+          val map = enum.values.toStream.zip(Stream.from(1)).toMap
+          map.asJson.as[Map[EntryType, Int]] shouldBe Right(map)
+        }
+      }
+
+      describe("from JSON") {
+        it("should fail to parse random JSON into a map") {
+          val invalidJsonMap = Stream.from(1).map(_.toString).take(10).toStream.zip(Stream.from(1)).toMap.asJson
+          invalidJsonMap.as[Map[EntryType, Int]].isLeft shouldBe true
+        }
+      }
     }
   }
 

--- a/enumeratum-circe/src/test/scala/enumeratum/values/CirceValueEnumSpec.scala
+++ b/enumeratum-circe/src/test/scala/enumeratum/values/CirceValueEnumSpec.scala
@@ -2,7 +2,7 @@ package enumeratum.values
 
 import org.scalatest.{FunSpec, Matchers}
 import cats.syntax.either._
-import io.circe.{Decoder, Encoder, Json}
+import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder, Json}
 import io.circe.syntax._
 
 /**
@@ -16,6 +16,7 @@ class CirceValueEnumSpec extends FunSpec with Matchers {
   testCirceEnum("ShortCirceEnum", CirceDrinks)
   testCirceEnum("IntCirceEnum", CirceLibraryItem)
   testCirceEnum("StringCirceEnum", CirceOperatingSystem)
+  testCirceKeyEnum("StringCirceEnum", CirceOperatingSystem)
   testCirceEnum("CharEnum", CirceAlphabet)
   testCirceEnum("ByteEnum", CirceBites)
   testCirceEnum("IntCirceEnum with val value members", CirceMovieGenre)
@@ -57,6 +58,15 @@ class CirceValueEnumSpec extends FunSpec with Matchers {
 
       }
 
+    }
+  }
+
+  private def testCirceKeyEnum[EntryType <: ValueEnumEntry[String]: KeyEncoder: KeyDecoder](
+    enumKind: String,
+    enum: ValueEnum[String, EntryType] with CirceValueEnum[String, EntryType]
+  ): Unit = {
+    describe(s"$enumKind as Key") {
+      
     }
   }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.0.2
+sbt.version = 1.1.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ resolvers ++= Seq(
   Classpaths.sbtPluginReleases
 )
 
-lazy val neoScalafmtVersion = "1.14"
+lazy val neoScalafmtVersion = "1.15"
 
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % neoScalafmtVersion)
 


### PR DESCRIPTION
Thought that it was a nice addition to the `CirceStringEnum` to be able to be used as a key in `Map`s (i.e.: `Map[MyEnum, Int]`).

For that, Circe requires a `KeyEncoder` and a `KeyDecoder` to be present in the implicit scope. With current enumeratum's API, implementing those is trivial for enums that are based on strings, so it could be cool to provide it out of the box.