### PR TITLE
Add cats module

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ Integrations are available for:
 11. [Slick integration](#slick-integration)
 12. [ScalaCheck](#scalacheck)
 13. [Quill integration](#quill)
-14. [Benchmarking](#benchmarking)
-15. [Publishing](#publishing)
+14. [Cats integration](#cats)
+15. [Benchmarking](#benchmarking)
+16. [Publishing](#publishing)
 
 
 ## Quick start
@@ -1041,6 +1042,88 @@ implicit val greetingGetResult = getResultForEnum(Greeting)
 implicit val greetingOptionGetResult = optionalGetResultForEnum(Greeting)
 implicit val greetingSetParameter = setParameterForEnum(Greeting)
 implicit val greetingOptionSetParameter = optionalSetParameterForEnum(Greeting)
+```
+
+## Cats
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.beachape/enumeratum-cats.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.beachape/enumeratum-cats.11)
+
+### SBT
+
+To use enumeratum with [Cats](https://github.com/typelevel/cats):
+
+```scala
+libraryDependencies ++= Seq(
+    "com.beachape" %% "enumeratum-cats" % enumeratumCatsVersion
+)
+```
+
+### Usage
+
+This enumeratum module is mostly useful for generic derivation - providing instances for `Eq`, `Show` and `Hash`. So if you have structures (for example case classes) which
+contain enum values, you get the instances for the enum itself "for free". But it can be useful for standalone usage as,
+providing type-safe comparison and hashing.
+
+#### Enum
+
+```scala
+import enumeratum._
+
+sealed trait ShirtSize extends EnumEntry
+
+case object ShirtSize extends Enum[ShirtSize] with CatsEnum[ShirtSize] {
+
+  case object Small   extends ShirtSize
+  case object Medium  extends ShirtSize
+  case object Large   extends ShirtSize
+
+  val values = findValues
+
+}
+
+import cats.syntax.eq._
+import cats.syntax.show._
+
+val shirtSizeOne: ShirtSize = ...
+val shirtSizeTwo: ShirtSize = ...
+
+if(shirtSizeOne === shirtSizeTwo) { // note the third equals
+    printf("We got the same size, its hash is: %i", implicitly[Hash[TrafficLight]].hash(shirtSizeOne))
+} else {
+    printf("Shirt sizes mismatch: %s =!= %s", shirtSizeOne.show, shirtSizeTwo.show)
+}
+```
+
+#### ValueEnum
+
+There are two implementations for `ValueEnum`:
+* `CatsValueEnum` provides the same functionality as `CatsEnum` (except `Hash`)
+* `CatsOrderValueEnum` provides the same functionality as `CatsValueEnum` plus an instance of `cats.Order` (due to Scala 2 trait limitations, it's an `abstract class`, check out `CatsCustomOrderValueEnum` if you need a `trait`)
+
+```scala
+import enumeratum.values._
+
+sealed abstract class CatsPriority(val value: Int, val name: String) extends IntEnumEntry
+
+case object CatsPriority extends IntEnum[CatsPriority] with CatsOrderValueEnum[Int, CatsPriority] {
+
+  // A good mix of named, unnamed, named + unordered args
+  case object Low         extends CatsPriority(value = 1, name = "low")
+  case object Medium      extends CatsPriority(name = "medium", value = 2)
+  case object High        extends CatsPriority(3, "high")
+  case object SuperHigh   extends CatsPriority(4, name = "super_high")
+
+  val values = findValues
+
+}
+
+import cats.instances.int._
+import cats.instances.list._
+import cats.syntax.order._
+import cats.syntax.foldable._
+
+val items: List[CatsPriority] = List(High, Low, SuperHigh)
+
+items.maximumOption // Some(SuperHigh)
 ```
 
 ## Benchmarking

--- a/README.md
+++ b/README.md
@@ -1057,6 +1057,14 @@ libraryDependencies ++= Seq(
 )
 ```
 
+To use with ScalaJS:
+
+```scala
+libraryDependencies ++= Seq(
+    "com.beachape" %%% "enumeratum-cats" % enumeratumCatsVersion
+)
+```
+
 ### Usage
 
 This enumeratum module is mostly useful for generic derivation - providing instances for `Eq`, `Show` and `Hash`. So if you have structures (for example case classes) which
@@ -1125,6 +1133,9 @@ val items: List[CatsPriority] = List(High, Low, SuperHigh)
 
 items.maximumOption // Some(SuperHigh)
 ```
+
+#### Inheritance-free usage
+If you need instances, but hesitate to mix in the traits demonstrated above, you can get them using the provided methods in `enumeratum.Cats` and `enumeratum.values.Cats` - the second also provides more flexibility than the (opinionated) mix-in trait as it allows to pass a custom type class instance for the value type (methods names are prefixed with `value`).
 
 ## Benchmarking
 

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,14 @@ def theSlickVersion(scalaVersion: String) =
       throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
   }
 
+def theCatsVersion(scalaVersion: String) =
+  CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2, scalaMajor)) if scalaMajor >= 11 => "1.4.0"
+    case Some((2, scalaMajor)) if scalaMajor == 10 => "1.2.0"
+    case _ =>
+      throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
+  }
+
 def thePlayJsonVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, scalaMajor)) if scalaMajor >= 11 => "2.6.10"
@@ -409,6 +417,18 @@ lazy val enumeratumSlick =
         "com.typesafe.slick" %% "slick"      % theSlickVersion(scalaVersion.value),
         "com.beachape"       %% "enumeratum" % Versions.Core.stable,
         "com.h2database"     % "h2"          % "1.4.197" % Test
+      )
+    )
+
+lazy val enumeratumCats =
+  Project(id = "enumeratum-cats", base = file("enumeratum-cats"))
+    .settings(commonWithPublishSettings: _*)
+    .settings(testSettings: _*)
+    .settings(
+      version := "1.5.16-SNAPSHOT",
+      libraryDependencies ++= Seq(
+        "org.typelevel" %% "cats-core"  % theCatsVersion(scalaVersion.value),
+        "com.beachape"  %% "enumeratum" % Versions.Core.stable
       )
     )
 

--- a/enumeratum-cats/src/main/scala/enumeratum/Cats.scala
+++ b/enumeratum-cats/src/main/scala/enumeratum/Cats.scala
@@ -1,0 +1,22 @@
+package enumeratum
+import cats.instances.string._
+import cats.{Eq, Hash, Show}
+
+object Cats {
+
+  /**
+  * Builds an `Eq` instance which differentiates all enum values as it's based on universal equals.
+  */
+  def eqForEnum[A <: EnumEntry]: Eq[A] = Eq.fromUniversalEquals[A]
+
+  /**
+  * Builds a `Show` instance returning the entry name (respecting possible mixins).
+  */
+  def showForEnum[A <: EnumEntry]: Show[A] = Show.show[A](_.entryName)
+
+  /**
+  * `Hash` instance based on the entry name.
+  */
+  def hashForEnum[A <: EnumEntry]: Hash[A] = Hash.by[A, String](_.entryName)
+
+}

--- a/enumeratum-cats/src/main/scala/enumeratum/CatsEnum.scala
+++ b/enumeratum-cats/src/main/scala/enumeratum/CatsEnum.scala
@@ -1,0 +1,14 @@
+package enumeratum
+
+import cats.instances.string._
+import cats.{Eq, Hash, Show}
+
+trait CatsEnum[A <: EnumEntry] { this: Enum[A] =>
+
+  implicit val eqInstance: Eq[A] = Eq.fromUniversalEquals[A]
+
+  implicit val showInstance: Show[A] = Show.fromToString[A]
+
+  implicit val hashInstance: Hash[A] = Hash.by(_.entryName)
+
+}

--- a/enumeratum-cats/src/main/scala/enumeratum/CatsEnum.scala
+++ b/enumeratum-cats/src/main/scala/enumeratum/CatsEnum.scala
@@ -1,14 +1,22 @@
 package enumeratum
 
-import cats.instances.string._
 import cats.{Eq, Hash, Show}
 
 trait CatsEnum[A <: EnumEntry] { this: Enum[A] =>
 
-  implicit val eqInstance: Eq[A] = Eq.fromUniversalEquals[A]
+  /**
+    * `Eq` instance for the enum entries - treats all enum values as distinct.
+    */
+  implicit val eqInstance: Eq[A] = Cats.eqForEnum[A]
 
-  implicit val showInstance: Show[A] = Show.show(_.entryName)
+  /**
+    * `Show` instance for the enum entries - returns the (transformed) entry name.
+    */
+  implicit val showInstance: Show[A] = Cats.showForEnum[A]
 
-  implicit val hashInstance: Hash[A] = Hash.by(_.entryName)
+  /**
+    * `Hash` instance for the enum entries - based on entry name.
+    */
+  implicit val hashInstance: Hash[A] = Cats.hashForEnum[A]
 
 }

--- a/enumeratum-cats/src/main/scala/enumeratum/CatsEnum.scala
+++ b/enumeratum-cats/src/main/scala/enumeratum/CatsEnum.scala
@@ -7,7 +7,7 @@ trait CatsEnum[A <: EnumEntry] { this: Enum[A] =>
 
   implicit val eqInstance: Eq[A] = Eq.fromUniversalEquals[A]
 
-  implicit val showInstance: Show[A] = Show.fromToString[A]
+  implicit val showInstance: Show[A] = Show.show(_.entryName)
 
   implicit val hashInstance: Hash[A] = Hash.by(_.entryName)
 

--- a/enumeratum-cats/src/main/scala/enumeratum/values/Cats.scala
+++ b/enumeratum-cats/src/main/scala/enumeratum/values/Cats.scala
@@ -1,0 +1,38 @@
+package enumeratum.values
+import cats.{Eq, Hash, Order, Show}
+import cats.syntax.contravariant._
+
+object Cats {
+
+  /**
+    * Builds an `Eq` instance which differentiates all enum values as it's based on universal equals.
+    */
+  def eqForEnum[A <: ValueEnumEntry[_]]: Eq[A] = Eq.fromUniversalEquals[A]
+
+  /**
+    * Builds an `Eq` instance which acts accordingly to the given `Eq` on the value type. Allows to implement different
+    * behaviour than [[eqForEnum]], for example grouping several enum values in special contexts.
+    */
+  def valueEqForEnum[A <: ValueEnumEntry[V], V : Eq]: Eq[A] = Eq.by[A, V](_.value)
+
+  /**
+    * Builds a `Show` instance based on `toString`.
+    */
+  def showForEnum[A <: ValueEnumEntry[_]]: Show[A] = Show.fromToString[A]
+
+  /**
+    * Builds a `Show` instance from the given `Show` on the value type.
+    */
+  def valueShowForEnum[A <: ValueEnumEntry[V], V: Show]: Show[A] = Show[V].contramap[A](_.value)
+
+  /**
+    * Builds a `Order` instance from the given `Order` on the value type.
+    */
+  def valueOrderForEnum[A <: ValueEnumEntry[V], V: Order]: Order[A] = Order.by[A, V](_.value)
+
+  /**
+    * Builds a `Hash` instance from the given `Hash` on the value type.
+    */
+  def valueOrderForEnum[A <: ValueEnumEntry[V], V: Hash]: Hash[A] = Hash.by[A, V](_.value)
+
+}

--- a/enumeratum-cats/src/main/scala/enumeratum/values/CatsValueEnum.scala
+++ b/enumeratum-cats/src/main/scala/enumeratum/values/CatsValueEnum.scala
@@ -5,18 +5,30 @@ import cats.{Eq, Order, Show}
 trait CatsValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]] {
   this: ValueEnum[ValueType, EntryType] =>
 
-  implicit val eqInstance: Eq[EntryType] = Eq.fromUniversalEquals[EntryType]
+  /**
+    * `Eq` instance for the enum entries - treats all enum values as distinct.
+    */
+  implicit val eqInstance: Eq[EntryType] = Cats.eqForEnum[EntryType]
 
-  implicit val showInstance: Show[EntryType] = Show.fromToString[EntryType]
+  /**
+    * Builds a `Show` instance based on `toString`.
+    */
+  implicit val showInstance: Show[EntryType] = Cats.showForEnum[EntryType]
 
 }
 
 trait CatsCustomOrderValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]] {
   this: ValueEnum[ValueType, EntryType] =>
 
+  /**
+    * Order for the enum's value type - used to derive [[orderInstance]].
+    */
   implicit val valueTypeOrder: Order[ValueType]
 
-  implicit val orderInstance: Order[EntryType] = Order.by(_.value)
+  /**
+    * Builds a `Order` instance from the given `Order` (see [[valueTypeOrder]] on the value type.
+    */
+  implicit val orderInstance: Order[EntryType] = Cats.valueOrderForEnum[EntryType, ValueType](valueTypeOrder)
 
 }
 

--- a/enumeratum-cats/src/main/scala/enumeratum/values/CatsValueEnum.scala
+++ b/enumeratum-cats/src/main/scala/enumeratum/values/CatsValueEnum.scala
@@ -1,0 +1,28 @@
+package enumeratum.values
+
+import cats.{Eq, Order, Show}
+
+trait CatsValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]] {
+  this: ValueEnum[ValueType, EntryType] =>
+
+  implicit val eqInstance: Eq[EntryType] = Eq.fromUniversalEquals[EntryType]
+
+  implicit val showInstance: Show[EntryType] = Show.fromToString[EntryType]
+
+}
+
+trait CatsCustomOrderValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]] {
+  this: ValueEnum[ValueType, EntryType] =>
+
+  implicit val valueTypeOrder: Order[ValueType]
+
+  implicit val orderInstance: Order[EntryType] = Order.by(_.value)
+
+}
+
+abstract class CatsOrderValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]](
+    implicit override val valueTypeOrder: Order[ValueType])
+    extends CatsCustomOrderValueEnum[ValueType, EntryType] {
+  this: ValueEnum[ValueType, EntryType] =>
+  // nothing needed here
+}

--- a/enumeratum-cats/src/test/scala/enumeratum/CatsEnumSpec.scala
+++ b/enumeratum-cats/src/test/scala/enumeratum/CatsEnumSpec.scala
@@ -1,0 +1,46 @@
+package enumeratum
+
+import cats.{Eq, Hash, Show}
+import cats.syntax.eq._
+import cats.syntax.show._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+
+class CatsEnumSpec extends FreeSpec with ScalaFutures with Matchers with BeforeAndAfterAll {
+
+  "CatsEnum" - {
+    "has a proper Eq instance" - {
+      val eq = implicitly[Eq[TrafficLight]]
+      "Eq works for equal values" in {
+        // === doesn't work as Scalatest has its own variant
+        assert(eq.eqv(TrafficLight.Red, TrafficLight.Red))
+        assert(eq.eqv(TrafficLight.Yellow, TrafficLight.Yellow))
+        assert(eq.eqv(TrafficLight.Green, TrafficLight.Green))
+      }
+      "Eq works for non-equal values" in {
+        assert((TrafficLight.Red: TrafficLight) =!= (TrafficLight.Yellow: TrafficLight))
+        assert((TrafficLight.Yellow: TrafficLight) =!= (TrafficLight.Green: TrafficLight))
+        assert((TrafficLight.Green: TrafficLight) =!= (TrafficLight.Red: TrafficLight))
+      }
+    }
+    "has a proper Show instance" - {
+      val _ = implicitly[Show[TrafficLight]]
+      "it returns the entry's name" in {
+        val trafficLight: TrafficLight = TrafficLight.Red
+        trafficLight.show shouldBe TrafficLight.Red.entryName
+      }
+    }
+    "has a Hash instance" - {
+      val _ = implicitly[Hash[TrafficLight]]
+    }
+  }
+}
+
+sealed trait TrafficLight extends EnumEntry
+object TrafficLight extends Enum[TrafficLight] with CatsEnum[TrafficLight] {
+  case object Red    extends TrafficLight
+  case object Yellow extends TrafficLight
+  case object Green  extends TrafficLight
+
+  val values = findValues
+}

--- a/enumeratum-cats/src/test/scala/enumeratum/values/CatsOrderValueEnumSpec.scala
+++ b/enumeratum-cats/src/test/scala/enumeratum/values/CatsOrderValueEnumSpec.scala
@@ -1,0 +1,38 @@
+package enumeratum.values
+
+import cats.Order
+import cats.instances.int._
+import cats.syntax.order._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FreeSpec, Matchers}
+
+class CatsOrderValueEnumSpec extends FreeSpec with ScalaFutures with Matchers {
+
+  "CatsOrderedValueEnum" - {
+    "has a proper Order instance" - {
+      val _ = implicitly[Order[OrderedTrafficLight]]
+      "respect the underlying Order for equal values" in {
+        ((OrderedTrafficLight.Red: OrderedTrafficLight) compare OrderedTrafficLight.Red) shouldBe 0
+        ((OrderedTrafficLight.Yellow: OrderedTrafficLight) compare OrderedTrafficLight.Yellow) shouldBe 0
+        ((OrderedTrafficLight.Green: OrderedTrafficLight) compare OrderedTrafficLight.Green) shouldBe 0
+      }
+      "respect the underlying Order for non-equal values" in {
+        ((OrderedTrafficLight.Red: OrderedTrafficLight) compare OrderedTrafficLight.Yellow) < 0 shouldBe true
+        ((OrderedTrafficLight.Yellow: OrderedTrafficLight) compare OrderedTrafficLight.Green) < 0 shouldBe true
+        ((OrderedTrafficLight.Green: OrderedTrafficLight) compare OrderedTrafficLight.Red) > 0 shouldBe true
+      }
+    }
+  }
+}
+
+sealed abstract class OrderedTrafficLight(val value: Int) extends IntEnumEntry
+
+object OrderedTrafficLight
+    extends CatsOrderValueEnum[Int, OrderedTrafficLight]
+    with IntEnum[OrderedTrafficLight] {
+  case object Red    extends OrderedTrafficLight(1)
+  case object Yellow extends OrderedTrafficLight(2)
+  case object Green  extends OrderedTrafficLight(3)
+
+  val values = findValues
+}

--- a/enumeratum-cats/src/test/scala/enumeratum/values/CatsValueEnumSpec.scala
+++ b/enumeratum-cats/src/test/scala/enumeratum/values/CatsValueEnumSpec.scala
@@ -1,0 +1,43 @@
+package enumeratum.values
+
+import cats.syntax.eq._
+import cats.syntax.show._
+import cats.{Eq, Show}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FreeSpec, Matchers}
+
+class CatsValueEnumSpec extends FreeSpec with ScalaFutures with Matchers {
+
+  "CatsValueEnum" - {
+    "has a proper Eq instance" - {
+      val eq = implicitly[Eq[TrafficLight]]
+      "Eq works for equal values" in {
+        // === doesn't work as Scalatest has its own variant
+        assert(eq.eqv(TrafficLight.Red, TrafficLight.Red))
+        assert(eq.eqv(TrafficLight.Yellow, TrafficLight.Yellow))
+        assert(eq.eqv(TrafficLight.Green, TrafficLight.Green))
+      }
+      "Eq works for non-equal values" in {
+        assert((TrafficLight.Red: TrafficLight) =!= (TrafficLight.Yellow: TrafficLight))
+        assert((TrafficLight.Yellow: TrafficLight) =!= (TrafficLight.Green: TrafficLight))
+        assert((TrafficLight.Green: TrafficLight) =!= (TrafficLight.Red: TrafficLight))
+      }
+    }
+    "has a proper Show instance" - {
+      val _ = implicitly[Show[TrafficLight]]
+      "it returns the entry's name" in {
+        val trafficLight: TrafficLight = TrafficLight.Red
+        trafficLight.show shouldBe "Red"
+      }
+    }
+  }
+}
+
+sealed abstract class TrafficLight(val value: Int) extends IntEnumEntry
+object TrafficLight extends IntEnum[TrafficLight] with CatsValueEnum[Int, TrafficLight] {
+  case object Red    extends TrafficLight(1)
+  case object Yellow extends TrafficLight(2)
+  case object Green  extends TrafficLight(3)
+
+  val values = findValues
+}


### PR DESCRIPTION
This PR adds support for some basic type classes from `cats-core`:
- `Eq` for typesafe comparison
- `Show` for pretty printing
- `Hash` for abstracting of hashing of values

Corresponding enumeratum-style mixins are provided for these, supporting both `Enum` and `ValueEnum`. The second also comes in an extended version which provides an instance of `Order`.

Major use cases are generic derivation and operations on collections of (nested) enum values, for example sorting a list of errors by their (enum) priority. See `Readme.md` for small examples.