### PR TITLE
Bump Scala to 2.12.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
         - sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION scalafmt::test test:compile test:doc
         - travis_wait 30 sleep 1800 &
         - sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION test
-    - scala: 2.12.6
+    - scala: 2.12.7
       jdk: oraclejdk8
       script:
         - sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION test:compile test:doc

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import com.typesafe.sbt.SbtGit.{GitKeys => git}
 
-lazy val theScalaVersion = "2.12.6"
+lazy val theScalaVersion = "2.12.7"
 
-lazy val scalaVersions = Seq("2.10.7", "2.11.12", "2.12.6")
+lazy val scalaVersions = Seq("2.10.7", "2.11.12", "2.12.7")
 
 lazy val scalaTestVersion  = "3.0.5"
 lazy val scalacheckVersion = "1.13.5"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
 


### PR DESCRIPTION
Release notes: https://github.com/scala/scala/releases/tag/v2.12.7

> Compiler performance has improved significantly again, and is mostly on par with 2.13. Concretely, you should see a 10% drop in compile times since 2.12.6, according to our compiler benchmarks.