### PR TITLE
Fix Eval so that it finds the classes directory for PR Snapshots

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -468,8 +468,7 @@ lazy val resolverSettings = Seq(
   resolvers ++= Seq(
     "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/",
     "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
-    "Sonatype releases" at "https://oss.sonatype.org/content/repositories/releases",
-    "Scala PR" at "https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots"
+    "Sonatype releases" at "https://oss.sonatype.org/content/repositories/releases"
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -456,7 +456,8 @@ lazy val resolverSettings = Seq(
   resolvers ++= Seq(
     "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/",
     "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
-    "Sonatype releases" at "https://oss.sonatype.org/content/repositories/releases"
+    "Sonatype releases" at "https://oss.sonatype.org/content/repositories/releases",
+    "Scala PR" at "https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots"
   )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import com.typesafe.sbt.SbtGit.{GitKeys => git}
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
+import sbtbuildinfo.BuildInfoPlugin.autoImport._
 
 lazy val theScalaVersion = "2.12.7"
 
@@ -190,6 +191,17 @@ lazy val enumeratumTestJs  = enumeratumTest.js
 lazy val enumeratumTestJvm = enumeratumTest.jvm
 
 lazy val coreJVMTests = Project(id = "coreJVMTests", base = file("enumeratum-core-jvm-tests"))
+  .enablePlugins(BuildInfoPlugin)
+  .settings(
+    buildInfoKeys := Seq[BuildInfoKey](name,
+                                       version,
+                                       scalaVersion,
+                                       sbtVersion,
+                                       BuildInfoKey.action("macrosJVMClassesDir") {
+                                         ((macrosJVM / classDirectory) in Compile).value
+                                       }),
+    buildInfoPackage := "enumeratum"
+  )
   .settings(commonWithPublishSettings: _*)
   .settings(testSettings: _*)
   .settings(

--- a/enumeratum-core-jvm-tests/src/test/scala/enumeratum/Eval.scala
+++ b/enumeratum-core-jvm-tests/src/test/scala/enumeratum/Eval.scala
@@ -31,7 +31,9 @@ object Eval {
     val PreReleasePattern = """.*-(M|RC).*""".r
     val Pattern           = """(\d+\.\d+)\..*""".r
     val SnapshotPattern   = """(\d+\.\d+\.\d+)-\d+-\d+-.*""".r
+    val PRSnapshotPattern = """(\d+\.\d+)\.\d+-[a-zA-Z0-9]+-[a-fA-F0-9]+-.*""".r
     scala.util.Properties.versionNumberString match {
+      case PRSnapshotPattern(v)     => v
       case s @ PreReleasePattern(_) => s
       case SnapshotPattern(v)       => v + "-SNAPSHOT"
       case Pattern(v)               => v

--- a/enumeratum-core-jvm-tests/src/test/scala/enumeratum/Eval.scala
+++ b/enumeratum-core-jvm-tests/src/test/scala/enumeratum/Eval.scala
@@ -19,26 +19,8 @@ object Eval {
 
   def macroToolboxClassPath = {
     val paths = Seq(
-      new java.io.File(s"macros/.jvm/target/scala-$scalaBinaryVersion/classes")
+      BuildInfo.macrosJVMClassesDir
     )
-    paths.foreach { p =>
-      if (!p.exists) sys.error(s"output directory ${p.getAbsolutePath} does not exist.")
-    }
     paths.map(_.getAbsolutePath)
   }
-
-  def scalaBinaryVersion: String = {
-    val PreReleasePattern = """.*-(M|RC).*""".r
-    val Pattern           = """(\d+\.\d+)\..*""".r
-    val SnapshotPattern   = """(\d+\.\d+\.\d+)-\d+-\d+-.*""".r
-    val PRSnapshotPattern = """(\d+\.\d+)\.\d+-[a-zA-Z0-9]+-[a-fA-F0-9]+-.*""".r
-    scala.util.Properties.versionNumberString match {
-      case PRSnapshotPattern(v)     => v
-      case s @ PreReleasePattern(_) => s
-      case SnapshotPattern(v)       => v + "-SNAPSHOT"
-      case Pattern(v)               => v
-      case _                        => ""
-    }
-  }
-
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,3 +21,5 @@ addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.3.5")
 addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.7.1")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")


### PR DESCRIPTION
Closes #211 

Resolve the PR snapshot versions to just major minor in terms of target directory.

Tested locally using instructions in #211:

```
sbt:enumeratum-root> ++2.12.9-bin-f96c8d2-SNAPSHOT!
[info] Forcing Scala version to 2.12.9-bin-f96c8d2-SNAPSHOT on all projects.
[info] Reapplying settings...
[info] Set current project to enumeratum-root (in build file:/Users/lloyd/Documents/skala/enumeratum/)
sbt:enumeratum-root> coreJVMTests/test
[info] EnumJVMSpec:
[info] findValues Vector
[info] - should be in the same order that the objects were declared in
[info] ValueEnumJVMSpec:
[info] IntEnum withValue
[info] - should return proper members for valid values but throw otherwise
[info] LongEnum withValue
[info] - should return proper members for valid values but throw otherwise
[info] ShortEnum withValue
[info] - should return proper members for valid values but throw otherwise
[info] ByteEnum withValue
[info] - should return proper members for valid values but throw otherwise
[info] StringEnum withValue
[info] - should return proper members for valid values but throw otherwise
[info] CharEnum withValue
[info] - should return proper members for valid values but throw otherwise
[info] Run completed in 38 seconds, 896 milliseconds.
[info] Total number of tests run: 7
[info] Suites: completed 2, aborted 0
[info] Tests: succeeded 7, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 42 s, completed Jan 17, 2019 9:48:15 PM
```

cc @SethTisue 