### PR TITLE
Circe KeyEncoder/KeyDecoder for Enum

### DIFF
--- a/enumeratum-circe/src/main/scala/enumeratum/Circe.scala
+++ b/enumeratum-circe/src/main/scala/enumeratum/Circe.scala
@@ -2,7 +2,7 @@ package enumeratum
 
 import cats.syntax.either._
 import io.circe.Decoder.Result
-import io.circe.{Encoder, Decoder, Json, HCursor, DecodingFailure}
+import io.circe.{Encoder, Decoder, Json, HCursor, DecodingFailure, KeyEncoder, KeyDecoder}
 
 /**
   * Created by Lloyd on 4/14/16.
@@ -79,6 +79,17 @@ object Circe {
         }
       }
     }
+
+  /**
+    * Returns a KeyEncoder for the given enum
+    */
+  def keyEncoder[A <: EnumEntry](enum: Enum[A]): KeyEncoder[A] = KeyEncoder.instance(_.entryName)
+
+  /**
+    * Returns a KeyDecoder for the given enum
+    */
+  def keyDecoder[A <: EnumEntry](enum: Enum[A]): KeyDecoder[A] =
+    KeyDecoder.instance(enum.withNameOption)
 
   private val stringEncoder = implicitly[Encoder[String]]
   private val stringDecoder = implicitly[Decoder[String]]

--- a/enumeratum-circe/src/main/scala/enumeratum/CirceKeyEnum.scala
+++ b/enumeratum-circe/src/main/scala/enumeratum/CirceKeyEnum.scala
@@ -1,0 +1,10 @@
+package enumeratum
+import io.circe.{KeyEncoder, KeyDecoder}
+
+/**
+  * Helper trait that adds implicit Circe KeyEncoder/KeyDecoder for an [[Enum]]'s members.
+  */
+trait CirceKeyEnum[A <: EnumEntry] { this: Enum[A] =>
+  implicit val circeKeyEncoder: KeyEncoder[A] = Circe.keyEncoder(this)
+  implicit val circeKeyDecoder: KeyDecoder[A] = Circe.keyDecoder(this)
+}

--- a/enumeratum-circe/src/test/scala/enumeratum/CirceKeySpec.scala
+++ b/enumeratum-circe/src/test/scala/enumeratum/CirceKeySpec.scala
@@ -1,0 +1,28 @@
+package enumeratum
+
+import org.scalatest.{FunSpec, Matchers}
+import cats.syntax.either._
+import io.circe.Json
+import io.circe.syntax._
+
+class CirceKeySpec extends FunSpec with Matchers {
+  describe("to JSON") {
+    it("should work") {
+      Map(ShirtSize.Small -> 5, ShirtSize.Large -> 10).asJson shouldBe Json.obj(
+        "Small" -> 5.asJson,
+        "Large" -> 10.asJson
+      )
+    }
+  }
+
+  describe("from JSON") {
+    it("should work") {
+      Json
+        .obj(
+          "Medium" -> 100.asJson,
+          "Large"  -> 15.asJson
+        )
+        .as[Map[ShirtSize, Int]] shouldBe Map(ShirtSize.Medium -> 100, ShirtSize.Large -> 15).asRight
+    }
+  }
+}

--- a/enumeratum-circe/src/test/scala/enumeratum/ShirtSize.scala
+++ b/enumeratum-circe/src/test/scala/enumeratum/ShirtSize.scala
@@ -5,9 +5,12 @@ package enumeratum
   *
   * Copyright 2016
   */
-sealed trait ShirtSize extends EnumEntry
+sealed trait ShirtSize extends EnumEntry with Product with Serializable
 
-case object ShirtSize extends CirceEnum[ShirtSize] with Enum[ShirtSize] {
+case object ShirtSize
+    extends CirceEnum[ShirtSize]
+    with CirceKeyEnum[ShirtSize]
+    with Enum[ShirtSize] {
 
   case object Small  extends ShirtSize
   case object Medium extends ShirtSize


### PR DESCRIPTION
It will be nice to have key encoder/decoder for non-value based enums, since there is one for string enum.

