### PR TITLE
Added anorm support for standard and value enums

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,15 @@ def theSlickVersion(scalaVersion: String) =
       throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
   }
 
+def theAnorm(scalaVersion: String) =
+    CrossVersion.partialVersion(scalaVersion) match {
+      case Some((2, scalaMajor)) if scalaMajor >= 11 =>
+        "org.playframework.anorm" %% "anorm" % "2.6.2"
+      case Some((2, scalaMajor)) if scalaMajor == 10 => "com.typesafe.play" %% "anorm" % "2.5.0"
+      case _ =>
+        throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
+    }
+
 def theCatsVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, scalaMajor)) if scalaMajor >= 11 => "1.5.0"
@@ -113,6 +122,7 @@ lazy val integrationProjectRefs = Seq(
   enumeratumQuillJs,
   enumeratumQuillJvm,
   enumeratumSlick,
+  enumeratumAnorm,
   enumeratumCatsJs,
   enumeratumCatsJvm
 ).map(Project.projectToRef)
@@ -396,6 +406,22 @@ lazy val enumeratumSlick =
         "com.h2database"     % "h2"          % "1.4.197" % Test
       )
     )
+
+lazy val enumeratumAnorm =
+    Project(id = "enumeratum-anorm", base = file("enumeratum-anorm"))
+      .settings(commonWithPublishSettings: _*)
+      .settings(testSettings: _*)
+      .settings(
+        version := "1.5.16-SNAPSHOT",
+        libraryDependencies ++= Seq(
+          theAnorm(scalaVersion.value),
+          "com.beachape"      %% "enumeratum"     % Versions.Core.stable,
+          "com.h2database"    % "h2"              % "1.4.199" % Test,
+          "com.typesafe.play" %% "play-jdbc"      % thePlayVersion(scalaVersion.value) % Test,
+          "ch.qos.logback"    % "logback-classic" % "1.2.3" % Test,
+          "ch.qos.logback"    % "logback-core"    % "1.2.3" % Test
+        )
+      )
 
 lazy val catsAggregate = aggregateProject("cats", enumeratumCatsJs, enumeratumCatsJvm)
 lazy val enumeratumCats = crossProject(JSPlatform, JVMPlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -38,13 +38,13 @@ def theSlickVersion(scalaVersion: String) =
   }
 
 def theAnorm(scalaVersion: String) =
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor)) if scalaMajor >= 11 =>
-        "org.playframework.anorm" %% "anorm" % "2.6.2"
-      case Some((2, scalaMajor)) if scalaMajor == 10 => "com.typesafe.play" %% "anorm" % "2.5.0"
-      case _ =>
-        throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
-    }
+  CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2, scalaMajor)) if scalaMajor >= 11 =>
+      "org.playframework.anorm" %% "anorm" % "2.6.2"
+    case Some((2, scalaMajor)) if scalaMajor == 10 => "com.typesafe.play" %% "anorm" % "2.5.0"
+    case _ =>
+      throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
+  }
 
 def theCatsVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
@@ -408,20 +408,20 @@ lazy val enumeratumSlick =
     )
 
 lazy val enumeratumAnorm =
-    Project(id = "enumeratum-anorm", base = file("enumeratum-anorm"))
-      .settings(commonWithPublishSettings: _*)
-      .settings(testSettings: _*)
-      .settings(
-        version := "1.5.16-SNAPSHOT",
-        libraryDependencies ++= Seq(
-          theAnorm(scalaVersion.value),
-          "com.beachape"      %% "enumeratum"     % Versions.Core.stable,
-          "com.h2database"    % "h2"              % "1.4.199" % Test,
-          "com.typesafe.play" %% "play-jdbc"      % thePlayVersion(scalaVersion.value) % Test,
-          "ch.qos.logback"    % "logback-classic" % "1.2.3" % Test,
-          "ch.qos.logback"    % "logback-core"    % "1.2.3" % Test
-        )
+  Project(id = "enumeratum-anorm", base = file("enumeratum-anorm"))
+    .settings(commonWithPublishSettings: _*)
+    .settings(testSettings: _*)
+    .settings(
+      version := "1.5.16-SNAPSHOT",
+      libraryDependencies ++= Seq(
+        theAnorm(scalaVersion.value),
+        "com.beachape"      %% "enumeratum"     % Versions.Core.stable,
+        "com.h2database"    % "h2"              % "1.4.199" % Test,
+        "com.typesafe.play" %% "play-jdbc"      % thePlayVersion(scalaVersion.value) % Test,
+        "ch.qos.logback"    % "logback-classic" % "1.2.3" % Test,
+        "ch.qos.logback"    % "logback-core"    % "1.2.3" % Test
       )
+    )
 
 lazy val catsAggregate = aggregateProject("cats", enumeratumCatsJs, enumeratumCatsJvm)
 lazy val enumeratumCats = crossProject(JSPlatform, JVMPlatform)

--- a/enumeratum-anorm/src/main/scala-2.10/enumeratum/package.scala
+++ b/enumeratum-anorm/src/main/scala-2.10/enumeratum/package.scala
@@ -1,0 +1,10 @@
+import anorm.{Column, MetaDataItem, SqlRequestError, MayErr}
+
+package object enumeratum {
+  implicit class ColumnOps[A](val column: Column[A]) extends AnyVal {
+    final def mapResult[B](f: A => Either[SqlRequestError, B]): Column[B] =
+      Column[B] { (v: Any, m: MetaDataItem) =>
+        column(v, m).flatMap(x => MayErr(f(x)))
+      }
+  }
+}

--- a/enumeratum-anorm/src/main/scala/enumeratum/AnormEnumColumnSupport.scala
+++ b/enumeratum-anorm/src/main/scala/enumeratum/AnormEnumColumnSupport.scala
@@ -1,0 +1,40 @@
+package enumeratum
+import anorm.{Column, TypeDoesNotMatch}
+
+/**
+  * Allows for easy creation of Column[_] instances for use with anorm parsers.
+  * Column instances are used when mapping query results back to Scala types.
+  * Can be used by importing singleton methods or mixing in the trait.
+  * {{{
+  * scala> import enumeratum._
+  *
+  * scala> sealed trait TrafficLight extends EnumEntry
+  * scala> object TrafficLight extends Enum[TrafficLight] {
+  *      |   case object Red    extends TrafficLight
+  *      |   case object Yellow extends TrafficLight
+  *      |   case object Green  extends TrafficLight
+  *      |   val values = findValues
+  *      | }
+  * scala> import AnormEnumColumnSupport._
+  * scala> implicit val trafficLightColumn = columnForEnum(TrafficLight)
+  * }}}
+  */
+trait AnormEnumColumnSupport {
+  def columnForEnum[E <: EnumEntry](enum: Enum[E]): Column[E] =
+    columnForEnum(enum.withNameOption _)
+
+  def columnForEnumInsensitive[E <: EnumEntry](enum: Enum[E]): Column[E] =
+    columnForEnum(enum.withNameInsensitiveOption _)
+
+  def columnForEnumUppercase[E <: EnumEntry](enum: Enum[E]): Column[E] =
+    columnForEnum(enum.withNameUppercaseOnlyOption _)
+
+  def columnForEnumLowercase[E <: EnumEntry](enum: Enum[E]): Column[E] =
+    columnForEnum(enum.withNameLowercaseOnlyOption _)
+
+  private def columnForEnum[E <: EnumEntry](find: String => Option[E]): Column[E] =
+    implicitly[Column[String]].mapResult { string =>
+      find(string).toRight(TypeDoesNotMatch(s"unsupported value: $string"))
+    }
+}
+object AnormEnumColumnSupport extends AnormEnumColumnSupport

--- a/enumeratum-anorm/src/main/scala/enumeratum/AnormEnumSupport.scala
+++ b/enumeratum-anorm/src/main/scala/enumeratum/AnormEnumSupport.scala
@@ -1,0 +1,3 @@
+package enumeratum
+
+trait AnormEnumSupport extends AnormEnumColumnSupport with AnormEnumToStatementSupport

--- a/enumeratum-anorm/src/main/scala/enumeratum/AnormEnumToStatementSupport.scala
+++ b/enumeratum-anorm/src/main/scala/enumeratum/AnormEnumToStatementSupport.scala
@@ -1,0 +1,48 @@
+package enumeratum
+import java.sql.PreparedStatement
+
+import anorm.ToStatement
+
+/**
+  * Allows for easy creation of ToStatement[_] instances for use with anorm queries.
+  * ToStatement instances are used when inserting Scala types into interpolated sql queries.
+  * Can be used by importing singleton methods or mixing in the trait.
+  * {{{
+  * scala> import enumeratum._
+  *
+  * scala> sealed trait TrafficLight extends EnumEntry
+  * scala> object TrafficLight extends Enum[TrafficLight] {
+  *      |   case object Red    extends TrafficLight
+  *      |   case object Yellow extends TrafficLight
+  *      |   case object Green  extends TrafficLight
+  *      |   val values = findValues
+  *      | }
+  * scala> import AnormEnumToStatementSupport._
+  * scala> implicit val trafficLightToStatement = toStatementForEnum(TrafficLight)
+  * }}}
+  */
+trait AnormEnumToStatementSupport {
+  def toStatementForEnum[E <: EnumEntry](enum: Enum[E]): ToStatement[E] = {
+    /* Implementation note: the enum argument is not used directly, but is used
+       for type inference - if it wasn't required the caller would have to pass a type
+       parameter, which would make the interface for toStatement different from everything
+       else. For consistency at the call site, we just ask for the enum itself as direct argument
+     */
+    toStatementForEnum(nameFunc = identity)
+  }
+
+  def toStatementForEnumUppercase[E <: EnumEntry](enum: Enum[E]): ToStatement[E] =
+    toStatementForEnum(_.toUpperCase)
+
+  def toStatementForEnumLowercase[E <: EnumEntry](enum: Enum[E]): ToStatement[E] =
+    toStatementForEnum(_.toLowerCase)
+
+  private def toStatementForEnum[E <: EnumEntry](nameFunc: String => String): ToStatement[E] =
+    new ToStatement[E] {
+      def set(s: PreparedStatement, index: Int, v: E): Unit = {
+        val transformedName = nameFunc(v.entryName)
+        s.setString(index, transformedName)
+      }
+    }
+}
+object AnormEnumToStatementSupport extends AnormEnumToStatementSupport

--- a/enumeratum-anorm/src/main/scala/enumeratum/values/AnormValueEnumColumnSupport.scala
+++ b/enumeratum-anorm/src/main/scala/enumeratum/values/AnormValueEnumColumnSupport.scala
@@ -1,0 +1,31 @@
+package enumeratum
+package values
+
+import anorm.{Column, TypeDoesNotMatch}
+
+/**
+  * Allows for easy creation of Column[_] instances for use with anorm parsers.
+  * Column instances are used when mapping query results back to Scala types.
+  * Can be used by importing singleton methods or mixing in the trait.
+  * {{{
+  * scala> import enumeratum.values._
+  *
+  * scala> sealed abstract class TrafficLightByInt(val value: Int) extends IntEnumEntry
+  * scala> object TrafficLightByInt extends IntEnum[TrafficLightByInt] {
+  *      |   case object Red    extends TrafficLightByInt(0)
+  *      |   case object Yellow extends TrafficLightByInt(1)
+  *      |   case object Green  extends TrafficLightByInt(2)
+  *      |   val values = findValues
+  *      | }
+  * scala> import AnormValueEnumColumnSupport._
+  * scala> implicit val trafficLightColumn = columnForValueEnum(TrafficLightByInt)
+  * }}}
+  */
+trait AnormValueEnumColumnSupport {
+  def columnForValueEnum[ValueType: Column, E <: ValueEnumEntry[ValueType]](
+      enum: ValueEnum[ValueType, E]): Column[E] =
+    implicitly[Column[ValueType]].mapResult { value =>
+      enum.withValueOpt(value).toRight(TypeDoesNotMatch(s"unsupported value: $value"))
+    }
+}
+object AnormValueEnumColumnSupport extends AnormValueEnumColumnSupport

--- a/enumeratum-anorm/src/main/scala/enumeratum/values/AnormValueEnumSupport.scala
+++ b/enumeratum-anorm/src/main/scala/enumeratum/values/AnormValueEnumSupport.scala
@@ -1,0 +1,5 @@
+package enumeratum.values
+
+trait AnormValueEnumSupport
+    extends AnormValueEnumToStatementSupport
+    with AnormValueEnumColumnSupport

--- a/enumeratum-anorm/src/main/scala/enumeratum/values/AnormValueEnumToStatementSupport.scala
+++ b/enumeratum-anorm/src/main/scala/enumeratum/values/AnormValueEnumToStatementSupport.scala
@@ -1,0 +1,40 @@
+package enumeratum
+package values
+
+import java.sql.PreparedStatement
+
+import anorm.ToStatement
+
+/**
+  * Allows for easy creation of ToStatement[_] instances for use with anorm queries.
+  * ToStatement instances are used when inserting Scala types into interpolated sql queries.
+  * Can be used by importing singleton methods or mixing in the trait.
+  * {{{
+  * scala> import enumeratum.values._
+  *
+  * scala> sealed abstract class TrafficLightByInt(val value: Int) extends IntEnumEntry
+  * scala> object TrafficLightByInt extends IntEnum[TrafficLightByInt] {
+  *      |   case object Red    extends TrafficLightByInt(0)
+  *      |   case object Yellow extends TrafficLightByInt(1)
+  *      |   case object Green  extends TrafficLightByInt(2)
+  *      |   val values = findValues
+  *      | }
+  * scala> import AnormValueEnumToStatementSupport._
+  * scala> implicit val trafficLightColumn = toStatementForValueEnum(TrafficLightByInt)
+  * }}}
+  */
+trait AnormValueEnumToStatementSupport {
+  def toStatementForValueEnum[ValueType: ToStatement, E <: ValueEnumEntry[ValueType]](
+      enum: ValueEnum[ValueType, E]): ToStatement[E] = {
+    /* Implementation note: the enum argument is not used directly, but is used
+       for type inference - if it wasn't required the caller would have to pass a type
+       parameter, which would make the interface for toStatement different from everything
+       else. For consistency at the call site, we just ask for the enum itself as direct argument
+     */
+    new ToStatement[E] {
+      def set(s: PreparedStatement, index: Int, v: E): Unit =
+        implicitly[ToStatement[ValueType]].set(s, index, v.value)
+    }
+  }
+}
+object AnormValueEnumToStatementSupport extends AnormValueEnumToStatementSupport

--- a/enumeratum-anorm/src/test/resources/logback-test.xml
+++ b/enumeratum-anorm/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>

--- a/enumeratum-anorm/src/test/scala/enumeratum/AnormEnumSupportTest.scala
+++ b/enumeratum-anorm/src/test/scala/enumeratum/AnormEnumSupportTest.scala
@@ -1,0 +1,115 @@
+package enumeratum
+import anorm.SqlParser._
+import anorm._
+import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+import play.api.db.Databases
+
+class AnormEnumSupportTest
+    extends FreeSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with AnormEnumSupport {
+
+  val db = Databases.inMemory()
+
+  val red: TrafficLight = TrafficLight.Red
+
+  "AnormEnumSupport" - {
+    "allows creation of working ToStatement[_] and Column[_] for standard enums" - {
+      "exact name" in {
+        implicit val trafficLightToStatement = toStatementForEnum(TrafficLight)
+        implicit val trafficLightColumn      = columnForEnum(TrafficLight)
+        val id ~ trafficLight                = trafficLightInfo(red)
+        id shouldBe 1
+        trafficLight shouldBe red
+      }
+      "insensitive" in {
+        implicit val trafficLightColumn = columnForEnumInsensitive(TrafficLight)
+        db.withConnection { implicit c =>
+          SQL"select value from traffic_light where id=6".as(scalar[TrafficLight].single)
+        } shouldBe red
+      }
+      "uppercase" in {
+        implicit val trafficLightToStatement = toStatementForEnumUppercase(TrafficLight)
+        implicit val trafficLightColumn      = columnForEnumUppercase(TrafficLight)
+        val id ~ trafficLight                = trafficLightInfo(red)
+        id shouldBe 2
+        trafficLight shouldBe red
+      }
+      "lowercase" in {
+        implicit val trafficLightToStatement = toStatementForEnumLowercase(TrafficLight)
+        implicit val trafficLightColumn      = columnForEnumLowercase(TrafficLight)
+        val id ~ trafficLight                = trafficLightInfo(red)
+        id shouldBe 3
+        trafficLight shouldBe red
+      }
+    }
+    "knows how to handle corner cases" - {
+      "fail to get enum from NULL" in {
+        a[AnormException] should be thrownBy db.withConnection { implicit c =>
+          implicit val trafficLightColumn = columnForEnum(TrafficLight)
+          SQL"select value from traffic_light where id=4".as(scalar[TrafficLight].single)
+        }
+      }
+      "fail to get unsupported value" in {
+        val exception = the[AnormException] thrownBy db.withConnection { implicit c =>
+          implicit val trafficLightColumn = columnForEnum(TrafficLight)
+          SQL"select value from traffic_light where id=5".as(scalar[TrafficLight].single)
+        }
+        exception.message should startWith("TypeDoesNotMatch")
+      }
+      "succeed when get option enum from NULL" in {
+        db.withConnection { implicit c =>
+          implicit val trafficLightColumn = columnForEnum(TrafficLight)
+          SQL"select value from traffic_light where id=4".as(scalar[Option[TrafficLight]].single)
+        } shouldBe empty
+      }
+    }
+  }
+
+  private def trafficLightInfo(trafficLight: TrafficLight)(
+      implicit toStatement: ToStatement[TrafficLight],
+      column: Column[TrafficLight]): Int ~ TrafficLight = {
+    db.withConnection { implicit c =>
+      SQL"select * from traffic_light where value=$trafficLight"
+        .as((int("id") ~ get[TrafficLight]("value")).single)
+    }
+  }
+
+  override protected def beforeAll(): Unit = {
+    db.withConnection { implicit c =>
+      SQL("""CREATE TABLE traffic_light (
+            |   id INT NOT NULL,
+            |   value VARCHAR(10)
+            |)""".stripMargin)
+        .execute()
+      db.withConnection { implicit c =>
+        implicit val toStatement = toStatementForEnum(TrafficLight)
+        SQL"insert into traffic_light values (1,$red)".executeInsert()
+      }
+      db.withConnection { implicit c =>
+        implicit val toStatement = toStatementForEnumUppercase(TrafficLight)
+        SQL"insert into traffic_light values (2,$red)".executeInsert()
+      }
+      db.withConnection { implicit c =>
+        implicit val toStatement = toStatementForEnumLowercase(TrafficLight)
+        SQL"insert into traffic_light values (3,$red)".executeInsert()
+      }
+      db.withConnection { implicit c =>
+        SQL"insert into traffic_light values (4,NULL),(5,'invalid'),(6,'rED')".executeInsert()
+      }
+    }
+  }
+  override protected def afterAll(): Unit = {
+    db.shutdown()
+  }
+}
+
+sealed trait TrafficLight extends EnumEntry
+object TrafficLight extends Enum[TrafficLight] {
+  case object Red    extends TrafficLight
+  case object Yellow extends TrafficLight
+  case object Green  extends TrafficLight
+
+  val values = findValues
+}

--- a/enumeratum-anorm/src/test/scala/enumeratum/values/AnormValueEnumSupportTest.scala
+++ b/enumeratum-anorm/src/test/scala/enumeratum/values/AnormValueEnumSupportTest.scala
@@ -1,0 +1,263 @@
+package enumeratum.values
+import anorm.SqlParser._
+import anorm._
+import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+import play.api.db.Databases
+
+class AnormValueEnumSupportTest
+    extends FreeSpec
+    with Matchers
+    with AnormValueEnumSupport
+    with BeforeAndAfterAll {
+  val db = Databases.inMemory()
+
+  implicit val toStatementIntEnum = toStatementForValueEnum(IntValueExample)
+  implicit val columnIntEnum      = columnForValueEnum(IntValueExample)
+
+  implicit val toStatementLongEnum = toStatementForValueEnum(LongValueExample)
+  implicit val columnLongEnum      = columnForValueEnum(LongValueExample)
+
+  implicit val toStatementByteEnum = toStatementForValueEnum(ByteValueExample)
+  implicit val columnByteEnum      = columnForValueEnum(ByteValueExample)
+
+  implicit val toStatementShortEnum = toStatementForValueEnum(ShortValueExample)
+  implicit val columnShortEnum      = columnForValueEnum(ShortValueExample)
+
+  implicit val toStatementCharEnum = toStatementForValueEnum(CharValueExample)
+  implicit val columnCharEnum      = columnForValueEnum(CharValueExample)
+
+  implicit val toStatementStringEnum = toStatementForValueEnum(StringValueExample)
+  implicit val columnStringEnum      = columnForValueEnum(StringValueExample)
+
+  val valueEnumParser = int("id") ~ get[IntValueExample]("int_value") ~ get[LongValueExample](
+    "long_value") ~ get[ByteValueExample]("byte_value") ~ get[ShortValueExample]("short_value") ~ get[
+    CharValueExample]("char_value") ~ get[StringValueExample]("string_value")
+
+  val intZero: IntValueExample       = IntValueExample.Zero
+  val longZero: LongValueExample     = LongValueExample.Zero
+  val byteZero: ByteValueExample     = ByteValueExample.Zero
+  val shortZero: ShortValueExample   = ShortValueExample.Zero
+  val charZero: CharValueExample     = CharValueExample.Zero
+  val stringZero: StringValueExample = StringValueExample.Zero
+
+  val intOne: IntValueExample       = IntValueExample.One
+  val longOne: LongValueExample     = LongValueExample.One
+  val byteOne: ByteValueExample     = ByteValueExample.One
+  val shortOne: ShortValueExample   = ShortValueExample.One
+  val charOne: CharValueExample     = CharValueExample.One
+  val stringOne: StringValueExample = StringValueExample.One
+
+  "AnormEnumSupport" - {
+    "allows creation of working Column[_] for value enums" - {
+      "zero" in {
+        val id ~ intEnum ~ longEnum ~ byteEnum ~ shortEnum ~ charEnum ~ stringEnum =
+          db.withConnection { implicit c =>
+            SQL"select * from value_enum where id=0".as(valueEnumParser.single)
+          }
+        id shouldBe 0
+        intEnum shouldBe intZero
+        longEnum shouldBe longZero
+        byteEnum shouldBe byteZero
+        shortEnum shouldBe shortZero
+        charEnum shouldBe charZero
+        stringEnum shouldBe stringZero
+      }
+      "one" in {
+        val id ~ intEnum ~ longEnum ~ byteEnum ~ shortEnum ~ charEnum ~ stringEnum =
+          db.withConnection { implicit c =>
+            SQL"select * from value_enum where id=1".as(valueEnumParser.single)
+          }
+        id shouldBe 1
+        intEnum shouldBe intOne
+        longEnum shouldBe longOne
+        byteEnum shouldBe byteOne
+        shortEnum shouldBe shortOne
+        charEnum shouldBe charOne
+        stringEnum shouldBe stringOne
+      }
+    }
+    "allows creation of working ToStatement[_] for value enums" - {
+      "int" in {
+        db.withConnection { implicit c =>
+          SQL"select id from value_enum where int_value=$intZero"
+            .as(scalar[Int].single)
+        } shouldBe 0
+        db.withConnection { implicit c =>
+          SQL"select id from value_enum where int_value=$intOne"
+            .as(scalar[Int].single)
+        } shouldBe 1
+      }
+      "long" in {
+        db.withConnection { implicit c =>
+          SQL"select id from value_enum where long_value=$longZero"
+            .as(scalar[Int].single)
+        } shouldBe 0
+        db.withConnection { implicit c =>
+          SQL"select id from value_enum where long_value=$longOne"
+            .as(scalar[Int].single)
+        } shouldBe 1
+      }
+      "byte" in {
+        db.withConnection { implicit c =>
+          SQL"select id from value_enum where byte_value=$byteZero"
+            .as(scalar[Int].single)
+        } shouldBe 0
+        db.withConnection { implicit c =>
+          SQL"select id from value_enum where byte_value=$byteOne"
+            .as(scalar[Int].single)
+        } shouldBe 1
+      }
+      "short" in {
+        db.withConnection { implicit c =>
+          SQL"select id from value_enum where short_value=$shortZero"
+            .as(scalar[Int].single)
+        } shouldBe 0
+        db.withConnection { implicit c =>
+          SQL"select id from value_enum where short_value=$shortOne"
+            .as(scalar[Int].single)
+        } shouldBe 1
+      }
+      "char" in {
+        db.withConnection { implicit c =>
+          SQL"select id from value_enum where string_value=$charZero"
+            .as(scalar[Int].single)
+        } shouldBe 0
+        db.withConnection { implicit c =>
+          SQL"select id from value_enum where string_value=$charOne"
+            .as(scalar[Int].single)
+        } shouldBe 1
+      }
+      "string" in {
+        db.withConnection { implicit c =>
+          SQL"select id from value_enum where int_value=$stringZero"
+            .as(scalar[Int].single)
+        } shouldBe 0
+        db.withConnection { implicit c =>
+          SQL"select id from value_enum where int_value=$stringOne"
+            .as(scalar[Int].single)
+        } shouldBe 1
+      }
+    }
+    "knows how to handle corner cases" - {
+      "fail to get enum from NULL" in {
+        a[AnormException] should be thrownBy db.withConnection { implicit c =>
+          SQL"select * from value_enum where id=3".as(
+            (
+              get[IntValueExample]("int_value") |
+                get[LongValueExample]("long_value") |
+                get[ByteValueExample]("byte_value") |
+                get[ShortValueExample]("short_value") |
+                get[CharValueExample]("char_value") |
+                get[StringValueExample]("string_value")
+            ).single)
+        }
+      }
+      "fail to get unsupported value" in {
+        val exception = the[AnormException] thrownBy db.withConnection { implicit c =>
+          SQL"select * from value_enum where id=2".as(
+            (
+              get[IntValueExample]("int_value") |
+                get[LongValueExample]("long_value") |
+                get[ByteValueExample]("byte_value") |
+                get[ShortValueExample]("short_value") |
+                get[CharValueExample]("char_value") |
+                get[StringValueExample]("string_value")
+            ).single)
+        }
+        exception.message should startWith("TypeDoesNotMatch")
+      }
+      "succeed when get option enum from NULL" in {
+        val intEnum ~ longEnum ~ byteEnum ~ shortEnum ~ charEnum ~ stringEnum = db.withConnection {
+          implicit c =>
+            SQL"select * from value_enum where id=3".as(
+              (
+                get[Option[IntValueExample]]("int_value") ~
+                  get[Option[LongValueExample]]("long_value") ~
+                  get[Option[ByteValueExample]]("byte_value") ~
+                  get[Option[ShortValueExample]]("short_value") ~
+                  get[Option[CharValueExample]]("char_value") ~
+                  get[Option[StringValueExample]]("string_value")
+              ).single)
+        }
+        intEnum shouldBe empty
+        longEnum shouldBe empty
+        byteEnum shouldBe empty
+        shortEnum shouldBe empty
+        charEnum shouldBe empty
+        stringEnum shouldBe empty
+      }
+    }
+
+  }
+
+  override protected def beforeAll(): Unit = {
+    db.withConnection { implicit c =>
+      SQL("""CREATE TABLE value_enum (
+            |   id INT NOT NULL,
+            |   int_value int,
+            |   long_value bigint,
+            |   byte_value tinyint,
+            |   short_value smallint,
+            |   char_value char,
+            |   string_value varchar(10)
+            |)""".stripMargin)
+        .execute()
+      db.withConnection { implicit c =>
+        SQL"""insert into value_enum values 
+              (0,0,0,0,0,0,0),
+             (1,1,1,1,1,1,1),
+             (2,2,2,2,2,2,2),
+             (3,null,null,null,null,null,null)"""
+          .executeInsert()
+      }
+    }
+  }
+  override protected def afterAll(): Unit = {
+    db.shutdown()
+  }
+}
+
+sealed abstract class IntValueExample(val value: Int) extends IntEnumEntry
+object IntValueExample extends IntEnum[IntValueExample] {
+  val values = findValues
+
+  case object Zero extends IntValueExample(0)
+  case object One  extends IntValueExample(1)
+}
+
+sealed abstract class LongValueExample(val value: Long) extends LongEnumEntry
+object LongValueExample extends LongEnum[LongValueExample] {
+  val values = findValues
+
+  case object Zero extends LongValueExample(0L)
+  case object One  extends LongValueExample(1L)
+}
+
+sealed abstract class ShortValueExample(val value: Short) extends ShortEnumEntry
+object ShortValueExample extends ShortEnum[ShortValueExample] {
+  val values = findValues
+
+  case object Zero extends ShortValueExample(0)
+  case object One  extends ShortValueExample(1)
+}
+sealed abstract class StringValueExample(val value: String) extends StringEnumEntry
+object StringValueExample extends StringEnum[StringValueExample] {
+  val values = findValues
+
+  case object Zero extends StringValueExample("0")
+  case object One  extends StringValueExample("1")
+}
+sealed abstract class ByteValueExample(val value: Byte) extends ByteEnumEntry
+object ByteValueExample extends ByteEnum[ByteValueExample] {
+  val values = findValues
+
+  case object Zero extends ByteValueExample(0)
+  case object One  extends ByteValueExample(1)
+}
+sealed abstract class CharValueExample(val value: Char) extends CharEnumEntry
+object CharValueExample extends CharEnum[CharValueExample] {
+  val values = findValues
+
+  case object Zero extends CharValueExample('0')
+  case object One  extends CharValueExample('1')
+}


### PR DESCRIPTION
This PR adds support for Anorm's `ToStatement[_]` and `Column[_]` type classes which make it easy to use enums in sql query interpolation and sql parsers.