### PR TITLE
Changed logic of CamelCase and LowerCamelCase EnumEntries

### DIFF
--- a/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
@@ -41,6 +41,20 @@ object EnumEntry {
     regexp2.matcher(first).replaceAll(replacement).split("_")
   }
 
+  private def word2Camel(str: String): String = {
+    capitalise(
+      str
+        .foldLeft(("", false, false)) {
+          case ((acc, prevUpper, twoPrevUpper), char) =>
+            val isUpper = char.isUpper
+            val newChar =
+              if (twoPrevUpper && !isUpper) char.toUpper else if (prevUpper) char.toLower else char
+            (acc + newChar.toString, isUpper, isUpper && prevUpper)
+        }
+        ._1
+    )
+  }
+
   private def capitalise(str: String): String = {
     if (str.isEmpty) str
     else str.take(1).toUpperCase + str.tail
@@ -101,7 +115,10 @@ object EnumEntry {
     override def entryName: String = stableEntryName
 
     private[this] lazy val stableEntryName: String =
-      super.entryName.split("_+").map(s => capitalise(s.toLowerCase)).mkString
+      super.entryName.split("_+") match {
+        case Array(single) => word2Camel(single)
+        case many          => many.map(s => capitalise(s.toLowerCase)).mkString
+      }
   }
 
   /**

--- a/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
@@ -307,11 +307,19 @@ class EnumSpec extends FunSpec with Matchers {
         CamelcaseEnum.withName("GoodBye") shouldBe CamelcaseEnum.GOOD_BYE
         CamelcaseEnum.withName("sikeagain") shouldBe CamelcaseEnum.SIKE_AGAIN
         CamelcaseEnum.withName("Private") shouldBe CamelcaseEnum._PRIVATE
+        CamelcaseEnum.withName("FromUpper") shouldBe CamelcaseEnum.FromUpper
+        CamelcaseEnum.withName("FromLower") shouldBe CamelcaseEnum.fromLower
+        CamelcaseEnum.withName("FromUpperToLower") shouldBe CamelcaseEnum.FromUPPERtoLOWER
+        CamelcaseEnum.withName("Lower") shouldBe CamelcaseEnum.lower
 
         LowerCamelcaseEnum.withName("hello") shouldBe LowerCamelcaseEnum.HELLO
         LowerCamelcaseEnum.withName("goodBye") shouldBe LowerCamelcaseEnum.GOOD_BYE
         LowerCamelcaseEnum.withName("SIKEAGAIN") shouldBe LowerCamelcaseEnum.SIKE_AGAIN
         LowerCamelcaseEnum.withName("private") shouldBe LowerCamelcaseEnum._PRIVATE
+        LowerCamelcaseEnum.withName("fromUpper") shouldBe LowerCamelcaseEnum.FromUpper
+        LowerCamelcaseEnum.withName("fromLower") shouldBe LowerCamelcaseEnum.fromLower
+        LowerCamelcaseEnum.withName("fromUpperToLower") shouldBe LowerCamelcaseEnum.FromUPPERtoLOWER
+        LowerCamelcaseEnum.withName("lower") shouldBe LowerCamelcaseEnum.lower
 
         UncapitalisedEnum.withName("hello") shouldBe UncapitalisedEnum.Hello
         UncapitalisedEnum.withName("goodBye") shouldBe UncapitalisedEnum.GoodBye

--- a/enumeratum-core/src/test/scala/enumeratum/Models.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/Models.scala
@@ -194,11 +194,14 @@ object CamelcaseEnum extends Enum[CamelcaseEnum] {
 
   val values = findValues
 
-  case object HELLO      extends CamelcaseEnum
-  case object GOOD_BYE   extends CamelcaseEnum
-  case object SIKE_AGAIN extends CamelcaseEnum with Lowercase
-  case object _PRIVATE   extends CamelcaseEnum
-
+  case object HELLO            extends CamelcaseEnum
+  case object GOOD_BYE         extends CamelcaseEnum
+  case object SIKE_AGAIN       extends CamelcaseEnum with Lowercase
+  case object _PRIVATE         extends CamelcaseEnum
+  case object FromUpper        extends CamelcaseEnum
+  case object fromLower        extends CamelcaseEnum
+  case object FromUPPERtoLOWER extends CamelcaseEnum
+  case object lower            extends CamelcaseEnum
 }
 
 sealed trait LowerCamelcaseEnum extends EnumEntry with LowerCamelcase
@@ -207,11 +210,14 @@ object LowerCamelcaseEnum extends Enum[LowerCamelcaseEnum] {
 
   val values = findValues
 
-  case object HELLO      extends LowerCamelcaseEnum
-  case object GOOD_BYE   extends LowerCamelcaseEnum
-  case object SIKE_AGAIN extends LowerCamelcaseEnum with Uppercase
-  case object _PRIVATE   extends LowerCamelcaseEnum
-
+  case object HELLO            extends LowerCamelcaseEnum
+  case object GOOD_BYE         extends LowerCamelcaseEnum
+  case object SIKE_AGAIN       extends LowerCamelcaseEnum with Uppercase
+  case object _PRIVATE         extends LowerCamelcaseEnum
+  case object FromUpper        extends LowerCamelcaseEnum
+  case object fromLower        extends LowerCamelcaseEnum
+  case object FromUPPERtoLOWER extends LowerCamelcaseEnum
+  case object lower            extends LowerCamelcaseEnum
 }
 
 sealed trait UncapitalisedEnum extends EnumEntry with Uncapitalised


### PR DESCRIPTION
I think is not right logic when entry FooBar have "Foobar" entryName in CamelCase enum and "foobar" entry in LowerCamelCase enum.
It can add support of transforming to CamelCase and LowerCamelCase not only delimited by "_" entries.