### PR TITLE
Adds support for doobie

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,9 +8,10 @@ lazy val theScalaVersion = "2.12.7"
   2.13.0-M5 support is currently defined as a separate project (scala_2_13) for convenience while
   integration libraries are still gaining 2.13 support
  */
-lazy val scalaVersions     = Seq("2.10.7", "2.11.12", "2.12.7")
-lazy val scala_2_13Version = "2.13.0-M5"
-lazy val scalaVersionsAll  = scalaVersions :+ scala_2_13Version
+lazy val scalaVersions           = Seq("2.10.7", "2.11.12", "2.12.7")
+lazy val scalaVersionsAbove_2_11 = Seq("2.11.12", "2.12.7")
+lazy val scala_2_13Version       = "2.13.0-M5"
+lazy val scalaVersionsAll        = scalaVersions :+ scala_2_13Version
 
 lazy val scalaTestVersion  = "3.0.6-SNAP4"
 lazy val scalacheckVersion = "1.14.0"
@@ -391,6 +392,7 @@ lazy val enumeratumDoobie =
     .settings(commonWithPublishSettings: _*)
     .settings(testSettings: _*)
     .settings(
+      crossScalaVersions := scalaVersionsAbove_2_11 :+ scala_2_13Version,
       version := "1.5.14-SNAPSHOT",
       libraryDependencies ++= {
         Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -113,6 +113,7 @@ lazy val integrationProjectRefs = Seq(
   enumeratumScalacheckJvm,
   enumeratumQuillJs,
   enumeratumQuillJvm,
+  enumeratumDoobie,
   enumeratumSlick,
   enumeratumCatsJs,
   enumeratumCatsJvm
@@ -385,26 +386,19 @@ lazy val enumeratumQuill = crossProject(JSPlatform, JVMPlatform)
 lazy val enumeratumQuillJs  = enumeratumQuill.js
 lazy val enumeratumQuillJvm = enumeratumQuill.jvm
 
-lazy val doobieAggregate = aggregateProject("doobie", enumeratumDoobieJvm).settings(
-  crossScalaVersions := post210Only(crossScalaVersions.value)
-)
-lazy val enumeratumDoobie = crossProject(JSPlatform, JVMPlatform)
-  .crossType(CrossType.Pure)
-  .in(file("enumeratum-doobie"))
-  .settings(commonWithPublishSettings: _*)
-  .settings(testSettings: _*)
-  .settings(
-    name := "enumeratum-doobie",
-    version := "1.5.14-SNAPSHOT",
-    crossScalaVersions := post210Only(crossScalaVersions.value),
-    libraryDependencies ++= {
-      Seq(
-        "com.beachape" %%% "enumeratum" % Versions.Core.stable,
-        "org.tpolecat" %% "doobie-core" % doobieVersion
-      )
-    }
-  )
-lazy val enumeratumDoobieJvm = enumeratumDoobie.jvm
+lazy val enumeratumDoobie =
+  Project(id = "enumeratum-doobie", base = file("enumeratum-doobie"))
+    .settings(commonWithPublishSettings: _*)
+    .settings(testSettings: _*)
+    .settings(
+      version := "1.5.14-SNAPSHOT",
+      libraryDependencies ++= {
+        Seq(
+          "com.beachape" %%% "enumeratum" % Versions.Core.stable,
+          "org.tpolecat" %% "doobie-core" % doobieVersion
+        )
+      }
+    )
 
 lazy val enumeratumSlick =
   Project(id = "enumeratum-slick", base = file("enumeratum-slick"))

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ lazy val reactiveMongoVersion = "0.13.0"
 lazy val argonautVersion      = "6.2.1"
 lazy val json4sVersion        = "3.6.1"
 lazy val quillVersion         = "2.3.3"
+lazy val doobieVersion        = "0.6.0"
 
 def thePlayVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
@@ -383,6 +384,27 @@ lazy val enumeratumQuill = crossProject(JSPlatform, JVMPlatform)
   )
 lazy val enumeratumQuillJs  = enumeratumQuill.js
 lazy val enumeratumQuillJvm = enumeratumQuill.jvm
+
+lazy val doobieAggregate = aggregateProject("doobie", enumeratumDoobieJvm).settings(
+  crossScalaVersions := post210Only(crossScalaVersions.value)
+)
+lazy val enumeratumDoobie = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("enumeratum-doobie"))
+  .settings(commonWithPublishSettings: _*)
+  .settings(testSettings: _*)
+  .settings(
+    name := "enumeratum-doobie",
+    version := "1.5.14-SNAPSHOT",
+    crossScalaVersions := post210Only(crossScalaVersions.value),
+    libraryDependencies ++= {
+      Seq(
+        "com.beachape" %%% "enumeratum" % Versions.Core.stable,
+        "org.tpolecat" %% "doobie-core" % doobieVersion
+      )
+    }
+  )
+lazy val enumeratumDoobieJvm = enumeratumDoobie.jvm
 
 lazy val enumeratumSlick =
   Project(id = "enumeratum-slick", base = file("enumeratum-slick"))

--- a/enumeratum-doobie/src/main/scala/enumeratum/Doobie.scala
+++ b/enumeratum-doobie/src/main/scala/enumeratum/Doobie.scala
@@ -1,0 +1,12 @@
+package enumeratum
+
+import doobie.util._
+
+object Doobie {
+
+  /**
+    * Returns an Encoder for the given enum
+    */
+  def meta[A <: EnumEntry](enum: Enum[A]): Meta[A] =
+    Meta[String].imap(enum.withName)(_.entryName)
+}

--- a/enumeratum-doobie/src/main/scala/enumeratum/DoobieEnum.scala
+++ b/enumeratum-doobie/src/main/scala/enumeratum/DoobieEnum.scala
@@ -1,0 +1,32 @@
+package enumeratum
+
+import doobie.util._
+
+/**
+  * Helper trait that adds implicit Doobie Get and Put for an [[Enum]]'s members
+  *
+  * Example:
+  *
+  * {{{
+  * scala> import enumeratum._
+  * scala> import doobie._
+  * scala> import doobie.implicits._
+  *
+  * scala> sealed trait ShirtSize extends EnumEntry
+  * scala> case object ShirtSize extends Enum[ShirtSize] with DoobieEnum[ShirtSize] {
+  *      |  case object Small  extends ShirtSize
+  *      |  case object Medium extends ShirtSize
+  *      |  case object Large  extends ShirtSize
+  *      |  val values = findValues
+  *      | }
+  *
+  * scala> case class Shirt(size: ShirtSize)
+  *
+  * scala> sql"select size from Shirt".query[Shirt].to[List]
+  * }}}
+  */
+trait DoobieEnum[A <: EnumEntry] { this: Enum[A] =>
+
+  implicit lazy val enumMeta: Meta[A] = Doobie.meta(this)
+
+}

--- a/enumeratum-doobie/src/main/scala/enumeratum/values/Doobie.scala
+++ b/enumeratum-doobie/src/main/scala/enumeratum/values/Doobie.scala
@@ -1,0 +1,15 @@
+package enumeratum.values
+
+import doobie.util._
+
+object Doobie {
+
+  def meta[ValueType, EntryType <: ValueEnumEntry[ValueType]](
+      enum: ValueEnum[ValueType, EntryType]
+  )(
+      implicit
+      get: Get[ValueType],
+      put: Put[ValueType]
+  ): Meta[EntryType] =
+    new Meta[ValueType](get, put).imap(enum.withValue)(_.value)
+}

--- a/enumeratum-doobie/src/main/scala/enumeratum/values/DoobieValueEnum.scala
+++ b/enumeratum-doobie/src/main/scala/enumeratum/values/DoobieValueEnum.scala
@@ -1,0 +1,79 @@
+package enumeratum.values
+
+import doobie.util._
+
+sealed trait DoobieValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType], DoobieType] {
+  this: ValueEnum[ValueType, EntryType] =>
+
+  implicit val meta: Meta[EntryType]
+}
+
+/**
+  * DoobieEnum for IntEnumEntry
+  *
+  * {{{
+  * scala> import enumeratum.values._
+  * scala> import doobie._
+  * scala> import doobie.implicits._
+  *
+  * scala> sealed abstract class ShirtSize(val value:Int) extends IntEnumEntry
+  * scala> case object ShirtSize extends IntEnum[ShirtSize] with IntDoobieEnum[ShirtSize] {
+  *      |  case object Small  extends ShirtSize(1)
+  *      |  case object Medium extends ShirtSize(2)
+  *      |  case object Large  extends ShirtSize(3)
+  *      |  val values = findValues
+  *      | }
+  *
+  * scala> case class Shirt(size: ShirtSize)
+  *
+  * scala> sql"select size from Shirt".query[Shirt].to[List]
+  * }}}
+  */
+trait IntDoobieEnum[EntryType <: IntEnumEntry] extends DoobieValueEnum[Int, EntryType, Int] {
+  this: ValueEnum[Int, EntryType] =>
+  implicit val meta: Meta[EntryType] = Doobie.meta(this)
+}
+
+/**
+  * DoobieEnum for LongEnumEntry
+  */
+trait LongDoobieEnum[EntryType <: LongEnumEntry] extends DoobieValueEnum[Long, EntryType, Long] {
+  this: ValueEnum[Long, EntryType] =>
+  implicit val meta: Meta[EntryType] = Doobie.meta(this)
+}
+
+/**
+  * DoobieEnum for ShortEnumEntry
+  */
+trait ShortDoobieEnum[EntryType <: ShortEnumEntry]
+    extends DoobieValueEnum[Short, EntryType, Short] {
+  this: ValueEnum[Short, EntryType] =>
+  implicit val meta: Meta[EntryType] = Doobie.meta(this)
+}
+
+/**
+  * DoobieEnum for StringEnumEntry
+  */
+trait StringDoobieEnum[EntryType <: StringEnumEntry]
+    extends DoobieValueEnum[String, EntryType, String] {
+  this: ValueEnum[String, EntryType] =>
+  implicit val meta: Meta[EntryType] = Doobie.meta(this)
+}
+
+/**
+  * DoobieEnum for CharEnumEntry
+  */
+trait CharDoobieEnum[EntryType <: CharEnumEntry] extends DoobieValueEnum[Char, EntryType, String] {
+  this: ValueEnum[Char, EntryType] =>
+
+  implicit val meta: Meta[EntryType] =
+    Meta[String].imap(str => withValue(str.charAt(0)))(enum => String.valueOf(enum.value))
+}
+
+/**
+  * DoobieEnum for ByteEnumEntry
+  */
+trait ByteDoobieEnum[EntryType <: ByteEnumEntry] extends DoobieValueEnum[Byte, EntryType, Byte] {
+  this: ValueEnum[Byte, EntryType] =>
+  implicit val meta: Meta[EntryType] = Doobie.meta(this)
+}

--- a/enumeratum-doobie/src/test/scala/enumeratum/DoobieEnumSpec.scala
+++ b/enumeratum-doobie/src/test/scala/enumeratum/DoobieEnumSpec.scala
@@ -1,0 +1,36 @@
+package enumeratum
+
+import org.scalatest.{FunSpec, Matchers}
+
+import doobie.util.{Read => DoobieRead, Write => DoobieWrite}
+import scala.collection.immutable
+
+class DoobieEnumSpec extends FunSpec with Matchers {
+
+  describe("A DoobieEnum") {
+
+    it("should have a Write") {
+      DoobieWrite[DoobieShirt]
+    }
+
+    it("should have a Read") {
+      DoobieRead[DoobieShirt]
+    }
+
+  }
+
+}
+
+sealed trait DoobieShirtSize extends EnumEntry
+
+case object DoobieShirtSize extends Enum[DoobieShirtSize] with DoobieEnum[DoobieShirtSize] {
+
+  case object Small  extends DoobieShirtSize
+  case object Medium extends DoobieShirtSize
+  case object Large  extends DoobieShirtSize
+
+  override val values: immutable.IndexedSeq[DoobieShirtSize] = findValues
+
+}
+
+case class DoobieShirt(size: DoobieShirtSize)

--- a/enumeratum-doobie/src/test/scala/enumeratum/values/DoobieValueEnumSpec.scala
+++ b/enumeratum-doobie/src/test/scala/enumeratum/values/DoobieValueEnumSpec.scala
@@ -1,0 +1,180 @@
+package enumeratum.values
+
+import cats.effect.{IO, Resource}
+import doobie.util.{Read => DoobieRead, Write => DoobieWrite}
+import org.scalatest.{FunSpec, Matchers}
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext
+import scala.collection.immutable
+import java.util.concurrent.{Executors, ExecutorService}
+
+class DoobieValueEnumSpec extends FunSpec with Matchers {
+
+  describe("An IntDoobieEnum") {
+
+    it("should have a Write") {
+      DoobieWrite[DoobieBorrowerToLibraryItem]
+    }
+
+    it("should have a Read") {
+      DoobieRead[DoobieBorrowerToLibraryItem]
+    }
+
+  }
+
+  describe("A LongDoobieEnum") {
+
+    it("should have a Write") {
+      DoobieWrite[DoobieContent]
+    }
+
+    it("should have a Read") {
+      DoobieRead[DoobieContent]
+    }
+
+  }
+
+  describe("A ShortDoobieEnum") {
+
+    it("should have a Write") {
+      DoobieWrite[DoobieDrinkManufacturer]
+    }
+
+    it("should have a Read") {
+      DoobieRead[DoobieDrinkManufacturer]
+    }
+
+  }
+
+  describe("A StringDoobieEnum") {
+
+    it("should have a Write") {
+      DoobieWrite[DoobieComputer]
+    }
+
+    it("should have a Read") {
+      DoobieRead[DoobieComputer]
+    }
+
+  }
+
+  describe("A CharDoobieEnum") {
+
+    it("should have a Write") {
+      DoobieWrite[DoobieName]
+    }
+
+    it("should have a Read") {
+      DoobieRead[DoobieName]
+    }
+
+  }
+
+  describe("A ByteDoobieEnum") {
+
+    it("should have a Write") {
+      DoobieWrite[DoobieChar]
+    }
+
+    it("should have a Read") {
+      DoobieRead[DoobieChar]
+    }
+
+  }
+
+}
+
+sealed abstract class DoobieLibraryItem(val value: Int, val name: String) extends IntEnumEntry
+
+case object DoobieLibraryItem
+    extends IntEnum[DoobieLibraryItem]
+    with IntDoobieEnum[DoobieLibraryItem] {
+
+  // A good mix of named, unnamed, named + unordered args
+  case object Book     extends DoobieLibraryItem(value = 1, name = "book")
+  case object Movie    extends DoobieLibraryItem(name = "movie", value = 2)
+  case object Magazine extends DoobieLibraryItem(3, "magazine")
+  case object CD       extends DoobieLibraryItem(4, name = "cd")
+
+  override val values: immutable.IndexedSeq[DoobieLibraryItem] = findValues
+
+}
+
+case class DoobieBorrowerToLibraryItem(borrower: String, item: DoobieLibraryItem)
+
+sealed abstract class DoobieContentType(val value: Long, name: String) extends LongEnumEntry
+
+case object DoobieContentType
+    extends LongEnum[DoobieContentType]
+    with LongDoobieEnum[DoobieContentType] {
+
+  override val values: immutable.IndexedSeq[DoobieContentType] = findValues
+
+  case object Text  extends DoobieContentType(value = 1L, name = "text")
+  case object Image extends DoobieContentType(value = 2L, name = "image")
+  case object Video extends DoobieContentType(value = 3L, name = "video")
+  case object Audio extends DoobieContentType(value = 4L, name = "audio")
+
+}
+
+case class DoobieContent(`type`: DoobieContentType)
+
+sealed abstract class DoobieDrink(val value: Short, name: String) extends ShortEnumEntry
+
+case object DoobieDrink extends ShortEnum[DoobieDrink] with ShortDoobieEnum[DoobieDrink] {
+
+  case object OrangeJuice extends DoobieDrink(value = 1, name = "oj")
+  case object AppleJuice  extends DoobieDrink(value = 2, name = "aj")
+  case object Cola        extends DoobieDrink(value = 3, name = "cola")
+  case object Beer        extends DoobieDrink(value = 4, name = "beer")
+
+  override val values: immutable.IndexedSeq[DoobieDrink] = findValues
+
+}
+
+case class DoobieDrinkManufacturer(name: String, drink: DoobieDrink)
+
+sealed abstract class DoobieOperatingSystem(val value: String) extends StringEnumEntry
+
+case object DoobieOperatingSystem
+    extends StringEnum[DoobieOperatingSystem]
+    with StringDoobieEnum[DoobieOperatingSystem] {
+
+  case object Linux   extends DoobieOperatingSystem("linux")
+  case object OSX     extends DoobieOperatingSystem("osx")
+  case object Windows extends DoobieOperatingSystem("windows")
+  case object Android extends DoobieOperatingSystem("android")
+
+  override val values: immutable.IndexedSeq[DoobieOperatingSystem] = findValues
+
+}
+
+case class DoobieComputer(operatingSystem: DoobieOperatingSystem)
+
+sealed abstract class DoobieAlphabet(val value: Char) extends CharEnumEntry
+
+case object DoobieAlphabet extends CharEnum[DoobieAlphabet] with CharDoobieEnum[DoobieAlphabet] {
+
+  case object A extends DoobieAlphabet('A')
+  case object B extends DoobieAlphabet('B')
+  case object C extends DoobieAlphabet('C')
+  case object D extends DoobieAlphabet('D')
+
+  override val values: immutable.IndexedSeq[DoobieAlphabet] = findValues
+
+}
+
+case class DoobieName(name: String, initials: DoobieAlphabet)
+
+sealed abstract class DoobieByte(val value: Byte) extends ByteEnumEntry
+
+object DoobieByte extends ByteEnum[DoobieByte] with ByteDoobieEnum[DoobieByte] {
+  override val values: immutable.IndexedSeq[DoobieByte] = findValues
+
+  case object OneByte   extends DoobieByte(1)
+  case object TwoByte   extends DoobieByte(2)
+  case object ThreeByte extends DoobieByte(3)
+  case object FourByte  extends DoobieByte(4)
+}
+
+case class DoobieChar(byte1: DoobieByte, byte2: DoobieByte)


### PR DESCRIPTION
closes https://github.com/lloydmeta/enumeratum/issues/186

The tests that I added only check whether there is a Read and Write for the enum types. They do not check however that the resulting values look good. The reason is to avoid adding extra dependencies like cats-effect and using an actual database like h2 or PostgreSQL. I could add them if necessary.

Also, for the version of the enumeratum-doobie module, I am not too sure where should it start.