### PR TITLE
2.13 RC branch merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
         - sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION scalafmtCheck scalafmtSbtCheck test:compile test:doc
         - travis_wait 30 sleep 1800 &
         - sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION test
-    - scala: 2.12.7
+    - scala: 2.12.8
       jdk: oraclejdk8
       script:
         - sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION test:compile test:doc
@@ -27,7 +27,7 @@ matrix:
         - sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION coverage test coverageReport
         - sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION coverageAggregate
       after_success: sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION coveralls
-    - scala: 2.13.0-M5
+    - scala: 2.13.0-RC2
       jdk: oraclejdk8
       script:
         - sbt ++$TRAVIS_SCALA_VERSION scala_2_13/test:compile scala_2_13/test:doc

--- a/build.sbt
+++ b/build.sbt
@@ -2,29 +2,30 @@ import com.typesafe.sbt.SbtGit.{GitKeys => git}
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 import sbtbuildinfo.BuildInfoPlugin.autoImport._
 
-lazy val theScalaVersion = "2.12.7"
+lazy val theScalaVersion = "2.12.8"
 
 /*
-  2.13.0-M5 support is currently defined as a separate project (scala_2_13) for convenience while
+  2.13.0-RC2 support is currently defined as a separate project (scala_2_13) for convenience while
   integration libraries are still gaining 2.13 support
  */
-lazy val scalaVersions           = Seq("2.10.7", "2.11.12", "2.12.7")
-lazy val scalaVersionsAbove_2_11 = Seq("2.11.12", "2.12.7")
-lazy val scala_2_13Version       = "2.13.0-RC1"
+lazy val scalaVersions           = Seq("2.10.7", "2.11.12", "2.12.8")
+lazy val scalaVersionsAbove_2_11 = Seq("2.11.12", "2.12.8")
+lazy val scala_2_13Version       = "2.13.0-RC2"
 lazy val scalaVersionsAll        = scalaVersions :+ scala_2_13Version
 
-lazy val scalaTestVersion  = "3.0.8-RC2"
+lazy val scalaTestVersion  = "3.0.8-RC4"
 lazy val scalacheckVersion = "1.14.0"
 
 // Library versions
 lazy val reactiveMongoVersion = "0.13.0"
-lazy val argonautVersion      = "6.2.1"
-lazy val json4sVersion        = "3.6.1"
+lazy val argonautVersion      = "6.2.3"
+lazy val json4sVersion        = "3.6.6"
 lazy val quillVersion         = "2.3.3"
 lazy val doobieVersion        = "0.6.0"
 
 def thePlayVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2, scalaMajor)) if scalaMajor >= 13 => "2.8.0-M1"
     case Some((2, scalaMajor)) if scalaMajor >= 11 => "2.7.0"
     case Some((2, scalaMajor)) if scalaMajor == 10 => "2.4.11"
     case _ =>
@@ -49,7 +50,8 @@ def theCatsVersion(scalaVersion: String) =
 
 def thePlayJsonVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
-    case Some((2, scalaMajor)) if scalaMajor >= 11 => "2.7.1"
+    case Some((2, scalaMajor)) if scalaMajor >= 13 => "2.8.0-M1"
+    case Some((2, scalaMajor)) if scalaMajor >= 11 => "2.7.3"
     case Some((2, scalaMajor)) if scalaMajor == 10 => "2.4.11"
     case _ =>
       throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
@@ -64,12 +66,24 @@ def theCirceVersion(scalaVersion: String) =
   }
 
 def scalaTestPlay(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
+  case Some((2, scalaMajor)) if scalaMajor >= 13 =>
+    "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0-M1" % Test
   case Some((2, scalaMajor)) if scalaMajor >= 11 =>
     "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.1" % Test
   case Some((2, scalaMajor)) if scalaMajor == 10 =>
     "org.scalatestplus" %% "play" % "1.4.0" % Test
   case _ =>
     throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
+}
+
+/** Temporary fix for Play 5.0.0-M1. */
+def akkaHttp(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
+  case Some((2, scalaMajor)) if scalaMajor >= 13 =>
+    Seq(
+      ("com.typesafe.play" %% "play-akka-http-server" % thePlayVersion(scalaVersion)) excludeAll ("com.typesafe.akka" %% "akka-http-core"),
+      "com.typesafe.akka"  %% "akka-http-core"        % "10.1.8"
+    )
+  case _ => Seq.empty
 }
 
 lazy val baseProjectRefs =
@@ -167,7 +181,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     name := "enumeratum",
     version := Versions.Core.head,
     crossScalaVersions := scalaVersionsAll,
-    libraryDependencies += "com.beachape" %% "enumeratum-macros" % Versions.Macros.stable
+    libraryDependencies += "com.beachape" %% "enumeratum-macros" % Versions.Macros.head
   )
 //  .dependsOn(macros) // used for testing macros
 lazy val coreJS  = core.js
@@ -276,12 +290,13 @@ lazy val enumeratumPlay = Project(id = "enumeratum-play", base = file("enumeratu
   .settings(
     version := s"1.5.17-SNAPSHOT",
     crossScalaVersions := scalaVersionsAll,
-    libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play"            % thePlayVersion(scalaVersion.value),
-      "com.beachape"      %% "enumeratum"      % Versions.Core.stable,
-      "com.beachape"      %% "enumeratum-test" % Versions.Core.stable % Test,
-      scalaTestPlay(scalaVersion.value)
-    )
+    libraryDependencies ++= akkaHttp(scalaVersion.value) ++ // Temporary fix for Play 5.0.0-M1
+      Seq(
+        "com.typesafe.play" %% "play"            % thePlayVersion(scalaVersion.value),
+        "com.beachape"      %% "enumeratum"      % Versions.Core.stable,
+        "com.beachape"      %% "enumeratum-test" % Versions.Core.stable % Test,
+        scalaTestPlay(scalaVersion.value)
+      )
   )
   .dependsOn(enumeratumPlayJsonJvm % "test->test;compile->compile")
 
@@ -356,7 +371,7 @@ lazy val enumeratumScalacheck = crossProject(JSPlatform, JVMPlatform)
       Seq(
         "com.beachape"   %%% "enumeratum"      % Versions.Core.stable,
         "org.scalacheck" %%% "scalacheck"      % scalacheckVersion,
-        "com.beachape"   %%% "enumeratum-test" % Versions.Core.stable % Test,
+        "com.beachape"   %%% "enumeratum-test" % Versions.Core.stable % Test
       )
     }
   )
@@ -472,8 +487,6 @@ lazy val compilerSettings = Seq(
       case _            => FastOptStage
     }
   },
-  wartremoverErrors in (Compile, compile) ++= Warts.unsafe
-    .filterNot(_ == Wart.DefaultArguments) :+ Wart.ExplicitImplicitTypes,
   scalacOptions in (Compile, compile) ++= {
     val base = Seq(
       "-Xlog-free-terms",
@@ -489,12 +502,12 @@ lazy val compilerSettings = Seq(
       "-Ywarn-dead-code", // N.B. doesn't work well with the ??? hole
       "-Ywarn-numeric-widen",
       "-Ywarn-value-discard",
-//      "-Xfuture"
+      "-Xfuture"
     )
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, m)) if m >= 13 =>
-        base.filterNot(_ == "-Xfatal-warnings") ++ // todo see how to disable deprecations in 2.13.x
-          Seq("-deprecation:false", "-Xlint:-unused,_") // unused-import breaks Circe Either shim
+        base.filterNot(flag => flag == "-Xfatal-warnings" || flag == "-Xfuture") ++ // todo see how to disable deprecations in 2.13.x
+          Seq( /*"-deprecation:false", */ "-Xlint:-unused,_") // unused-import breaks Circe Either shim
       case Some((2, m)) if m >= 12 =>
         base ++ Seq("-deprecation:false", "-Xlint:-unused,_") // unused-import breaks Circe Either shim
       case Some((2, 11)) => base ++ Seq("-deprecation:false", "-Xlint", "-Ywarn-unused-import")

--- a/build.sbt
+++ b/build.sbt
@@ -299,7 +299,7 @@ lazy val enumeratumPlay = Project(id = "enumeratum-play", base = file("enumeratu
   .settings(testSettings: _*)
   .settings(
     version := s"1.5.17-SNAPSHOT",
-    crossScalaVersions := scalaVersionsAbove_2_11 :+ scala_2_13Version,
+    crossScalaVersions := scalaVersionsAll,
     libraryDependencies ++= akkaHttp(scalaVersion.value) ++ // Temporary fix for Play 5.0.0-M1
       Seq(
         "com.typesafe.play" %% "play"            % thePlayVersion(scalaVersion.value),
@@ -308,7 +308,10 @@ lazy val enumeratumPlay = Project(id = "enumeratum-play", base = file("enumeratu
         scalaTestPlay(scalaVersion.value)
       )
   )
-  .dependsOn(enumeratumPlayJsonJvm % "test->test;compile->compile")
+  .settings(withCompatUnmanagedSources(jsJvmCrossProject = false,
+                                       include_210Dir = true,
+                                       includeTestSrcs = true): _*)
+  .dependsOn(enumeratumPlayJsonJvm % "compile->compile;test->test")
 
 lazy val circeAggregate = aggregateProject("circe", enumeratumCirceJs, enumeratumCirceJvm)
 lazy val enumeratumCirce = crossProject(JSPlatform, JVMPlatform)

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,14 @@ lazy val json4sVersion        = "3.6.6"
 lazy val quillVersion         = "2.3.3"
 lazy val doobieVersion        = "0.6.0"
 
+def theArgonautVersion(scalaVersion: String) =
+  CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2, scalaMajor)) if scalaMajor >= 11 => "6.2.3"
+    case Some((2, scalaMajor)) if scalaMajor == 10 => "6.2.2"
+    case _ =>
+      throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
+  }
+
 def thePlayVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, scalaMajor)) if scalaMajor >= 13 => "2.8.0-M1"
@@ -95,6 +103,8 @@ lazy val scala213ProjectRefs = Seq(
   enumeratumScalacheckJs,
   enumeratumPlayJsonJvm,
   enumeratumPlayJsonJs,
+  enumeratumArgonautJs,
+  enumeratumArgonautJvm,
   enumeratumPlay
 ).map(Project.projectToRef)
 
@@ -330,10 +340,11 @@ lazy val enumeratumArgonaut = crossProject(JSPlatform, JVMPlatform)
   .settings(
     name := "enumeratum-argonaut",
     version := "1.5.14-SNAPSHOT",
+    crossScalaVersions := scalaVersionsAll,
     libraryDependencies ++= {
       Seq(
         "com.beachape" %%% "enumeratum" % Versions.Core.stable,
-        "io.argonaut"  %%% "argonaut"   % argonautVersion
+        "io.argonaut"  %%% "argonaut"   % theArgonautVersion(scalaVersion.value)
       )
     }
   )

--- a/build.sbt
+++ b/build.sbt
@@ -10,10 +10,10 @@ lazy val theScalaVersion = "2.12.7"
  */
 lazy val scalaVersions           = Seq("2.10.7", "2.11.12", "2.12.7")
 lazy val scalaVersionsAbove_2_11 = Seq("2.11.12", "2.12.7")
-lazy val scala_2_13Version       = "2.13.0-M5"
+lazy val scala_2_13Version       = "2.13.0-RC1"
 lazy val scalaVersionsAll        = scalaVersions :+ scala_2_13Version
 
-lazy val scalaTestVersion  = "3.0.6-SNAP4"
+lazy val scalaTestVersion  = "3.0.8-RC2"
 lazy val scalacheckVersion = "1.14.0"
 
 // Library versions
@@ -489,9 +489,12 @@ lazy val compilerSettings = Seq(
       "-Ywarn-dead-code", // N.B. doesn't work well with the ??? hole
       "-Ywarn-numeric-widen",
       "-Ywarn-value-discard",
-      "-Xfuture"
+//      "-Xfuture"
     )
     CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, m)) if m >= 13 =>
+        base.filterNot(_ == "-Xfatal-warnings") ++ // todo see how to disable deprecations in 2.13.x
+          Seq("-deprecation:false", "-Xlint:-unused,_") // unused-import breaks Circe Either shim
       case Some((2, m)) if m >= 12 =>
         base ++ Seq("-deprecation:false", "-Xlint:-unused,_") // unused-import breaks Circe Either shim
       case Some((2, 11)) => base ++ Seq("-deprecation:false", "-Xlint", "-Ywarn-unused-import")

--- a/build.sbt
+++ b/build.sbt
@@ -299,7 +299,7 @@ lazy val enumeratumPlay = Project(id = "enumeratum-play", base = file("enumeratu
   .settings(testSettings: _*)
   .settings(
     version := s"1.5.17-SNAPSHOT",
-    crossScalaVersions := scalaVersionsAll,
+    crossScalaVersions := scalaVersionsAbove_2_11 :+ scala_2_13Version,
     libraryDependencies ++= akkaHttp(scalaVersion.value) ++ // Temporary fix for Play 5.0.0-M1
       Seq(
         "com.typesafe.play" %% "play"            % thePlayVersion(scalaVersion.value),

--- a/build.sbt
+++ b/build.sbt
@@ -181,7 +181,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     name := "enumeratum",
     version := Versions.Core.head,
     crossScalaVersions := scalaVersionsAll,
-    libraryDependencies += "com.beachape" %% "enumeratum-macros" % Versions.Macros.head
+    libraryDependencies += "com.beachape" %% "enumeratum-macros" % Versions.Macros.stable
   )
 //  .dependsOn(macros) // used for testing macros
 lazy val coreJS  = core.js

--- a/enumeratum-core/src/main/scala/enumeratum/values/ValueEnum.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/values/ValueEnum.scala
@@ -65,7 +65,7 @@ sealed trait ValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType]] {
   private lazy val existingEntriesString = values.map(_.value).mkString(", ")
 
   private def buildNotFoundMessage(i: ValueType): String = {
-    s"$i is not a member of ValueEnum ($existingEntriesString)"
+    s"${i.toString} is not a member of ValueEnum ($existingEntriesString)"
   }
 
 }

--- a/enumeratum-play-json/src/main/scala/enumeratum/values/EnumFormats.scala
+++ b/enumeratum-play-json/src/main/scala/enumeratum/values/EnumFormats.scala
@@ -53,7 +53,7 @@ object EnumFormats {
     * Format for Char
     */
   implicit val charFormat: Format[Char] = new Format[Char] {
-    def writes(o: Char): JsValue = JsString(s"$o")
+    def writes(o: Char): JsValue = JsString(o.toString)
 
     def reads(json: JsValue): JsResult[Char] = json match {
       case JsString(s) if s.length == 1 => JsSuccess(s.charAt(0))

--- a/enumeratum-play/compat/src/test/scala-2.10/enumeratum/helpers/ActionHelper.scala
+++ b/enumeratum-play/compat/src/test/scala-2.10/enumeratum/helpers/ActionHelper.scala
@@ -1,0 +1,9 @@
+package enumeratum.helpers
+
+import play.api.mvc.{Action, AnyContent, AnyContentAsEmpty, BodyParsers, Result}
+
+object ActionHelper {
+
+  def apply(block: => Result): Action[AnyContent] =
+    Action(block)
+}

--- a/enumeratum-play/compat/src/test/scala-2.11/enumeratum/helpers/ActionHelper.scala
+++ b/enumeratum-play/compat/src/test/scala-2.11/enumeratum/helpers/ActionHelper.scala
@@ -1,0 +1,11 @@
+package enumeratum.helpers
+
+import play.api.mvc.{Action, ActionBuilder, AnyContent, AnyContentAsEmpty, BodyParsers, Result}
+
+object ActionHelper {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  def apply(block: => Result): Action[AnyContent] =
+    new ActionBuilder.IgnoringBody().apply(block)
+}

--- a/enumeratum-play/compat/src/test/scala-2.13/enumeratum/helpers/ActionHelper.scala
+++ b/enumeratum-play/compat/src/test/scala-2.13/enumeratum/helpers/ActionHelper.scala
@@ -1,0 +1,11 @@
+package enumeratum.helpers
+
+import play.api.mvc.{Action, ActionBuilder, AnyContent, AnyContentAsEmpty, BodyParsers, Result}
+
+object ActionHelper {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  def apply(block: => Result): Action[AnyContent] =
+    new ActionBuilder.IgnoringBody().apply(block)
+}

--- a/enumeratum-play/src/main/scala/enumeratum/UrlBinders.scala
+++ b/enumeratum-play/src/main/scala/enumeratum/UrlBinders.scala
@@ -23,7 +23,7 @@ object UrlBinders {
           else enum.withNameOption(value)
         maybeBound match {
           case Some(v) => Right(v)
-          case _       => Left(s"Unknown value supplied for $enum '$value'")
+          case _       => Left(s"Unknown value supplied for ${enum.toString} '$value'")
         }
       }
     }
@@ -39,7 +39,7 @@ object UrlBinders {
       def bind(key: String, value: String): Either[String, A] = {
         enum.withNameLowercaseOnlyOption(value) match {
           case Some(v) => Right(v)
-          case _       => Left(s"Unknown value supplied for $enum '$value'")
+          case _       => Left(s"Unknown value supplied for ${enum.toString} '$value'")
         }
       }
     }
@@ -55,7 +55,7 @@ object UrlBinders {
       def bind(key: String, value: String): Either[String, A] = {
         enum.withNameUppercaseOnlyOption(value) match {
           case Some(v) => Right(v)
-          case _       => Left(s"Unknown value supplied for $enum '$value'")
+          case _       => Left(s"Unknown value supplied for ${enum.toString} '$value'")
         }
       }
     }
@@ -81,7 +81,7 @@ object UrlBinders {
             else enum.withNameOption(p)
           maybeBound match {
             case Some(v) => Right(v)
-            case _       => Left(s"Cannot parse parameter $key as an Enum: $this")
+            case _       => Left(s"Cannot parse parameter $key as an Enum: ${this.toString}")
           }
         }
       }
@@ -102,7 +102,7 @@ object UrlBinders {
         params.get(key).flatMap(_.headOption).map { p =>
           enum.withNameLowercaseOnlyOption(p) match {
             case Some(v) => Right(v)
-            case _       => Left(s"Cannot parse parameter $key as an Enum: $this")
+            case _       => Left(s"Cannot parse parameter $key as an Enum: ${this.toString}")
           }
         }
       }
@@ -123,7 +123,7 @@ object UrlBinders {
         params.get(key).flatMap(_.headOption).map { p =>
           enum.withNameUppercaseOnlyOption(p) match {
             case Some(v) => Right(v)
-            case _       => Left(s"Cannot parse parameter $key as an Enum: $this")
+            case _       => Left(s"Cannot parse parameter $key as an Enum: ${this.toString}")
           }
         }
       }

--- a/enumeratum-play/src/main/scala/enumeratum/values/UrlBinders.scala
+++ b/enumeratum-play/src/main/scala/enumeratum/values/UrlBinders.scala
@@ -24,7 +24,7 @@ object UrlBinders {
           maybeBound match {
             case Some(obj) => Right(obj)
             case None =>
-              Left(s"Unknown value supplied for $enum '" + value + "'")
+              Left(s"Unknown value supplied for ${enum.toString} '" + value + "'")
           }
         }
 
@@ -48,7 +48,7 @@ object UrlBinders {
             val maybeBound = enum.withValueOpt(s)
             maybeBound match {
               case Some(obj) => Right(obj)
-              case None      => Left(s"Unknown value supplied for $enum '$s'")
+              case None      => Left(s"Unknown value supplied for ${enum.toString} '${s.toString}'")
             }
           })
       }

--- a/enumeratum-play/src/test/scala/enumeratum/PlayEnumSpec.scala
+++ b/enumeratum-play/src/test/scala/enumeratum/PlayEnumSpec.scala
@@ -172,9 +172,10 @@ class PlayEnumSpec extends FunSpec with Matchers {
             import play.api.routing.sird._
             import play.api.routing._
             import play.api.mvc._
+            import scala.concurrent.ExecutionContext.Implicits.global
             val router = Router.from {
               case GET(p"/${pathBindableExtractor(greeting)}") =>
-                Action {
+                new ActionBuilder.IgnoringBody().apply {
                   Results.Ok(s"$greeting")
                 }
             }

--- a/enumeratum-play/src/test/scala/enumeratum/PlayEnumSpec.scala
+++ b/enumeratum-play/src/test/scala/enumeratum/PlayEnumSpec.scala
@@ -9,6 +9,7 @@ import org.scalatest.EitherValues._
 import play.api.mvc.{PathBindable, QueryStringBindable}
 import play.api.routing.sird.PathBindableExtractor
 import play.api.test.FakeRequest
+import enumeratum.helpers.ActionHelper
 
 class PlayEnumSpec extends FunSpec with Matchers {
 
@@ -172,10 +173,9 @@ class PlayEnumSpec extends FunSpec with Matchers {
             import play.api.routing.sird._
             import play.api.routing._
             import play.api.mvc._
-            import scala.concurrent.ExecutionContext.Implicits.global
             val router = Router.from {
               case GET(p"/${pathBindableExtractor(greeting)}") =>
-                new ActionBuilder.IgnoringBody().apply {
+                ActionHelper {
                   Results.Ok(s"$greeting")
                 }
             }

--- a/enumeratum-play/src/test/scala/enumeratum/values/PlayValueEnumHelpers.scala
+++ b/enumeratum-play/src/test/scala/enumeratum/values/PlayValueEnumHelpers.scala
@@ -7,6 +7,7 @@ import org.scalatest.OptionValues._
 import org.scalatest.EitherValues._
 import play.api.libs.json.{Format, JsNumber, JsValue}
 import play.api.test.FakeRequest
+import enumeratum.helpers.ActionHelper
 
 /**
   * Created by Lloyd on 4/13/16.
@@ -114,11 +115,10 @@ trait PlayValueEnumHelpers extends EnumJsonFormatHelpers { this: FunSpec with Ma
             import play.api.routing.sird._
             import play.api.routing._
             import play.api.mvc._
-            import scala.concurrent.ExecutionContext.Implicits.global
             enum.values.foreach { entry =>
               val router = Router.from {
                 case GET(p"/${enum.fromPath(greeting)}") =>
-                  new ActionBuilder.IgnoringBody().apply {
+                  ActionHelper {
                     Results.Ok(s"$greeting")
                   }
               }

--- a/enumeratum-play/src/test/scala/enumeratum/values/PlayValueEnumHelpers.scala
+++ b/enumeratum-play/src/test/scala/enumeratum/values/PlayValueEnumHelpers.scala
@@ -114,10 +114,11 @@ trait PlayValueEnumHelpers extends EnumJsonFormatHelpers { this: FunSpec with Ma
             import play.api.routing.sird._
             import play.api.routing._
             import play.api.mvc._
+            import scala.concurrent.ExecutionContext.Implicits.global
             enum.values.foreach { entry =>
               val router = Router.from {
                 case GET(p"/${enum.fromPath(greeting)}") =>
-                  Action {
+                  new ActionBuilder.IgnoringBody().apply {
                     Results.Ok(s"$greeting")
                   }
               }

--- a/macros/src/main/scala/enumeratum/EnumMacros.scala
+++ b/macros/src/main/scala/enumeratum/EnumMacros.scala
@@ -5,6 +5,7 @@ import ContextUtils.Context
 import scala.collection.immutable._
 import scala.util.control.NonFatal
 
+@SuppressWarnings(Array("org.wartremover.warts.StringPlusAny"))
 object EnumMacros {
 
   /**

--- a/macros/src/main/scala/enumeratum/ValueEnumMacros.scala
+++ b/macros/src/main/scala/enumeratum/ValueEnumMacros.scala
@@ -5,6 +5,7 @@ import ContextUtils.Context
 import scala.reflect.ClassTag
 import scala.collection.immutable._
 
+@SuppressWarnings(Array("org.wartremover.warts.StringPlusAny"))
 object ValueEnumMacros {
 
   /**
@@ -254,7 +255,7 @@ object ValueEnumMacros {
     val membersWithValues = treeWithVals.map { treeWithVal =>
       treeWithVal.tree.symbol -> treeWithVal.value
     }
-    val groupedByValue = membersWithValues.groupBy(_._2).mapValues(_.map(_._1))
+    val groupedByValue = membersWithValues.groupBy(_._2).view.mapValues(_.map(_._1))
     val (valuesWithOneSymbol, valuesWithMoreThanOneSymbol) =
       groupedByValue.partition(_._2.size <= 1)
     if (valuesWithOneSymbol.size != membersWithValues.toMap.keys.size) {

--- a/macros/src/main/scala/enumeratum/ValueEnumMacros.scala
+++ b/macros/src/main/scala/enumeratum/ValueEnumMacros.scala
@@ -255,7 +255,9 @@ object ValueEnumMacros {
     val membersWithValues = treeWithVals.map { treeWithVal =>
       treeWithVal.tree.symbol -> treeWithVal.value
     }
-    val groupedByValue = membersWithValues.groupBy(_._2).view.mapValues(_.map(_._1))
+    val groupedByValue = membersWithValues.groupBy(_._2).map {
+      case (k, v) => (k, v.map(_._1))
+    }
     val (valuesWithOneSymbol, valuesWithMoreThanOneSymbol) =
       groupedByValue.partition(_._2.size <= 1)
     if (valuesWithOneSymbol.size != membersWithValues.toMap.keys.size) {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,13 +10,13 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.5")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.27")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
 
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.3.5")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.1")
 
 addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.7.2")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,8 +16,6 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
 
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.1")
-
 addSbtPlugin("com.github.tkawachi" % "sbt-doctest" % "0.7.2")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")


### PR DESCRIPTION
Changes:
- ~Drops Play support for 2.10.x~
- Removes WartRemover (for now? might change if [this](https://stackoverflow.com/questions/56411871/choosing-sbt-plugin-version-based-on-cross-scala-version-for-sbt-1-x) gets answered)

Weirdness:
- ~For some reason, the 2.10.x travis build required me to publish a snapshot artefact...for 2.12...~