### PR TITLE
Update circe version for publishing enumeratum-circe on 2.13 (jvm+js)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,6 +67,7 @@ def thePlayJsonVersion(scalaVersion: String) =
 
 def theCirceVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2, scalaMajor)) if scalaMajor >= 13 => "0.12.0-M4"
     case Some((2, scalaMajor)) if scalaMajor >= 11 => "0.11.1"
     case Some((2, scalaMajor)) if scalaMajor == 10 => "0.9.3"
     case _ =>
@@ -103,7 +104,9 @@ lazy val scala213ProjectRefs = Seq(
   enumeratumPlayJsonJs,
   enumeratumArgonautJs,
   enumeratumArgonautJvm,
-  enumeratumPlay
+  enumeratumPlay,
+  enumeratumCirceJvm,
+  enumeratumCirceJs
 ).map(Project.projectToRef)
 
 lazy val scala_2_13 = Project(id = "scala_2_13", base = file("scala_2_13"))

--- a/build.sbt
+++ b/build.sbt
@@ -332,14 +332,13 @@ lazy val enumeratumCirce = crossProject(JSPlatform, JVMPlatform)
       )
     }
   )
-  .jsSettings(
-    libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, scalaMajor)) if scalaMajor >= 13 => Seq(
+  .jsSettings(libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, scalaMajor)) if scalaMajor >= 13 =>
+      Seq(
         "io.circe" %%% "not-java-time" % "0.2.0" % Test
       )
-      case _ => Seq()
-    }
-  ))
+    case _ => Seq()
+  }))
 lazy val enumeratumCirceJs  = enumeratumCirce.js
 lazy val enumeratumCirceJvm = enumeratumCirce.jvm
 

--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,6 @@ lazy val scala213ProjectRefs = Seq(
   enumeratumArgonautJvm,
   enumeratumPlay,
   enumeratumCirceJvm,
-  enumeratumCirceJs
 ).map(Project.projectToRef)
 
 lazy val scala_2_13 = Project(id = "scala_2_13", base = file("scala_2_13"))

--- a/build.sbt
+++ b/build.sbt
@@ -106,6 +106,7 @@ lazy val scala213ProjectRefs = Seq(
   enumeratumArgonautJvm,
   enumeratumPlay,
   enumeratumCirceJvm,
+  enumeratumCirceJs,
 ).map(Project.projectToRef)
 
 lazy val scala_2_13 = Project(id = "scala_2_13", base = file("scala_2_13"))
@@ -330,6 +331,14 @@ lazy val enumeratumCirce = crossProject(JSPlatform, JVMPlatform)
       )
     }
   )
+  .jsSettings(
+    libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, scalaMajor)) if scalaMajor >= 13 => Seq(
+        "io.circe" %%% "not-java-time" % "0.2.0" % Test
+      )
+      case _ => Seq()
+    }
+  ))
 lazy val enumeratumCirceJs  = enumeratumCirce.js
 lazy val enumeratumCirceJvm = enumeratumCirce.jvm
 


### PR DESCRIPTION
Hi, I noticed that enumeratum_circe has not published on 2.13 yet. Circe is available for 2.13 via `0.12.0-M4`. Tests pass on this version without modification.

