### PR TITLE
Add proper support for postgres enum

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -144,6 +144,7 @@ lazy val integrationProjectRefs = Seq(
   enumeratumQuillJs,
   enumeratumQuillJvm,
   enumeratumDoobie,
+  enumeratumDoobiePg,
   enumeratumSlick,
   enumeratumCatsJs,
   enumeratumCatsJvm
@@ -433,6 +434,21 @@ lazy val enumeratumDoobie =
         Seq(
           "com.beachape" %%% "enumeratum" % Versions.Core.stable,
           "org.tpolecat" %% "doobie-core" % doobieVersion
+        )
+      }
+    )
+
+lazy val enumeratumDoobiePg =
+  Project(id = "enumeratum-doobie-postgres", base = file("enumeratum-doobie-postgres"))
+    .settings(commonWithPublishSettings: _*)
+    .settings(testSettings: _*)
+    .settings(
+      crossScalaVersions := scalaVersionsAbove_2_11,
+      version := "1.5.16-SNAPSHOT",
+      libraryDependencies ++= {
+        Seq(
+          "com.beachape" %%% "enumeratum"     % Versions.Core.stable,
+          "org.tpolecat" %% "doobie-postgres" % doobieVersion,
         )
       }
     )

--- a/enumeratum-doobie-postgres/src/main/scala/enumeratum/postgres/DoobiePgEnum.scala
+++ b/enumeratum-doobie-postgres/src/main/scala/enumeratum/postgres/DoobiePgEnum.scala
@@ -1,0 +1,27 @@
+package enumeratum.postgres
+
+import doobie._
+import doobie.postgres.implicits.pgEnumStringOpt
+import enumeratum._
+
+import scala.reflect.runtime.universe.TypeTag
+
+object DoobiePgEnum {
+
+  /**
+    * {{{
+    *   trait Foo extends EnumEntry
+    *   object Foo extends Enum[Foo] {
+    *     case object Bar extends Foo
+    *
+    *     val values = findValues
+    *     implicit val doobieMeta: Meta[Foo] = DoobiePgEnum.meta("foo", Foo)
+    *   }
+    * }}}
+    * @param name type in postgres
+    * @return Meta[A] for the given enum
+    */
+  def meta[A <: EnumEntry: TypeTag](name: String, enum: Enum[A]): Meta[A] = {
+    pgEnumStringOpt(name, enum.withNameOption, _.entryName)
+  }
+}

--- a/enumeratum-doobie-postgres/src/main/scala/enumeratum/postgres/values/DoobiePgValueEnum.scala
+++ b/enumeratum-doobie-postgres/src/main/scala/enumeratum/postgres/values/DoobiePgValueEnum.scala
@@ -1,0 +1,13 @@
+package enumeratum.postgres.values
+
+import doobie._
+import doobie.postgres.implicits.pgEnumStringOpt
+import enumeratum.values.{StringEnumEntry, ValueEnum}
+
+import scala.reflect.runtime.universe.TypeTag
+
+object DoobiePgValueEnum {
+  def meta[A <: StringEnumEntry: TypeTag](name: String, enum: ValueEnum[String, A]): Meta[A] = {
+    pgEnumStringOpt(name, enum.withValueOpt, _.value)
+  }
+}

--- a/enumeratum-doobie-postgres/src/test/scala/enumeratum/posrgres/DoobiePgEnumSpec.scala
+++ b/enumeratum-doobie-postgres/src/test/scala/enumeratum/posrgres/DoobiePgEnumSpec.scala
@@ -1,0 +1,34 @@
+package enumeratum.posrgres
+
+import enumeratum._
+import org.scalatest.{FunSpec, Matchers}
+import doobie.{Read, Write, Meta}
+import enumeratum.postgres.DoobiePgEnum
+
+import scala.collection.immutable
+
+class DoobiePgEnumSpec extends FunSpec with Matchers {
+  describe("A DoobieEnum") {
+
+    it("should have a Write") {
+      Write[DoobieShirt]
+    }
+
+    it("should have a Read") {
+      Read[DoobieShirt]
+    }
+
+  }
+}
+
+sealed trait DoobieShirtSize extends EnumEntry
+case object DoobieShirtSize extends Enum[DoobieShirtSize] {
+  case object Small  extends DoobieShirtSize
+  case object Medium extends DoobieShirtSize
+  case object Large  extends DoobieShirtSize
+
+  override val values: immutable.IndexedSeq[DoobieShirtSize] = findValues
+  implicit val doobieMeta: Meta[DoobieShirtSize]             = DoobiePgEnum.meta("shirt_size", DoobieShirtSize)
+}
+
+case class DoobieShirt(size: DoobieShirtSize)

--- a/enumeratum-doobie-postgres/src/test/scala/enumeratum/posrgres/values/DoobiePgValueEnumSpec.scala
+++ b/enumeratum-doobie-postgres/src/test/scala/enumeratum/posrgres/values/DoobiePgValueEnumSpec.scala
@@ -1,0 +1,37 @@
+package enumeratum.posrgres.values
+
+import org.scalatest.{FunSpec, Matchers}
+import doobie.{Meta, Read, Write}
+import enumeratum.postgres.values.DoobiePgValueEnum
+import enumeratum.values.{StringEnum, StringEnumEntry}
+
+import scala.collection.immutable
+
+class DoobiePgValueEnumSpec extends FunSpec with Matchers {
+  describe("A StringDoobieEnum") {
+
+    it("should have a Write") {
+      Write[DoobieComputer]
+    }
+
+    it("should have a Read") {
+      Read[DoobieComputer]
+    }
+
+  }
+}
+
+sealed abstract class DoobieOperatingSystem(val value: String) extends StringEnumEntry
+case object DoobieOperatingSystem extends StringEnum[DoobieOperatingSystem] {
+
+  case object Linux   extends DoobieOperatingSystem("linux")
+  case object OSX     extends DoobieOperatingSystem("osx")
+  case object Windows extends DoobieOperatingSystem("windows")
+  case object Android extends DoobieOperatingSystem("android")
+
+  override val values: immutable.IndexedSeq[DoobieOperatingSystem] = findValues
+  implicit val doobieMeta: Meta[DoobieOperatingSystem] =
+    DoobiePgValueEnum.meta("operating_system", DoobieOperatingSystem)
+}
+
+case class DoobieComputer(operatingSystem: DoobieOperatingSystem)


### PR DESCRIPTION
Postgres enums are encoded with PgObject in jdbc (and doobie). PgObject is basically just a `(type: String, value: String)`pair, doobie-postgres has basic support for it. The approach will be different from other modules so I'd like to get some feedback.

Right now I have the very basic implementation, basically you need to feed a type name (in postgres) to `DoobiePgEnum.meta` and get back a `Meta` instance for your enum. I'd like to have a more convenient API but seems hard without using `lazy val` or macros.