### PR TITLE
Remove dependency on circe not-java-time in JS enumeratum-circe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -336,13 +336,6 @@ lazy val enumeratumCirce = crossProject(JSPlatform, JVMPlatform)
       )
     }
   )
-  .jsSettings(libraryDependencies ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, scalaMajor)) if scalaMajor >= 13 =>
-      Seq(
-        "io.circe" %%% "not-java-time" % "0.2.0" % Test
-      )
-    case _ => Seq()
-  }))
 lazy val enumeratumCirceJs  = enumeratumCirce.js
 lazy val enumeratumCirceJvm = enumeratumCirce.jvm
 


### PR DESCRIPTION
This is not needed as of circe 0.12.0

Confirmed in release notes: https://github.com/circe/circe/releases/tag/v0.12.0

circe/circe#1245 has discussion on it not being needed and resolution.