### PR TITLE
Adds Play 2.8.x support, drops Scala 2.10 support

### DIFF
--- a/.travis-jvmopts
+++ b/.travis-jvmopts
@@ -1,8 +1,8 @@
 # This is used to configure the sbt instance that Travis launches
 
--Xms2G
--Xmx2G
--Xss2M
+-Xms4G
+-Xmx4G
+-Xss4M
 -XX:MaxMetaspaceSize=1G
 -XX:+CMSClassUnloadingEnabled
 -XX:+UseConcMarkSweepGC

--- a/.travis-jvmopts
+++ b/.travis-jvmopts
@@ -4,4 +4,6 @@
 -Xmx2G
 -Xss2M
 -XX:MaxMetaspaceSize=1G
+-XX:+CMSClassUnloadingEnabled
+-XX:+UseConcMarkSweepGC
 -Dfile.encoding=UTF-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,19 +7,13 @@ env:
 # Only run aggregation 2.12
 matrix:
   include:
-    - scala: 2.10.7
-      jdk: openjdk8
-      script:
-        - sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION  test:compile test:doc
-        - travis_wait 30 sleep 1800 &
-        - travis_retry sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION test
     - scala: 2.11.12
       jdk: openjdk8
       script:
         - sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION scalafmtCheck scalafmtSbtCheck test:compile test:doc
         - travis_wait 30 sleep 1800 &
         - sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION test
-    - scala: 2.12.8
+    - scala: 2.12.10
       jdk: openjdk8
       script:
         - sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION test:compile test:doc
@@ -27,6 +21,12 @@ matrix:
         - sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION coverage test coverageReport
         - sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION coverageAggregate
       after_success: sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION coveralls
+    - scala: 2.13.1
+      jdk: openjdk8
+      script:
+        - sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION test:compile test:doc
+        - travis_wait 30 sleep 1800 &
+        - sbt -jvm-opts .travis-jvmopts ++$TRAVIS_SCALA_VERSION test
     - scala: 2.13.0
       jdk: openjdk8
       script:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Enumeratum has the following niceties:
 - All magic happens at compile-time so you know right away when things go awry
 - Comprehensive automated testing to make sure everything is in tip-top shape
 
-Enumeratum is published for Scala 2.10.x, 2.11.x, 2.12.x, 2.13.x as well as ScalaJS.
+Enumeratum is published for Scala 2.11.x, 2.12.x, 2.13.x as well as ScalaJS.
 
 Integrations are available for:
 
@@ -327,8 +327,7 @@ libraryDependencies ++= Seq(
 )
 ```
 
-Note that as of version 1.4.0, `enumeratum-play` for Scala 2.11 is compatible with Play 2.5+ while 2.10 is compatible with
-Play 2.4.x. Versions prior to 1.4.0 are compatible with 2.4.x.
+Note that as of version 1.4.0, `enumeratum-play` for Scala 2.11 is compatible with Play 2.5+
 
 ### Usage
 
@@ -469,8 +468,7 @@ libraryDependencies ++= Seq(
 )
 ```
 
-Note that as of version 1.4.0, `enumeratum-play` for Scala 2.11 is compatible with Play 2.5+ while 2.10 is compatible with
-Play 2.4.x. Versions prior to 1.4.0 are compatible with 2.4.x.
+Note that as of version 1.4.0, `enumeratum-play-json` for Scala 2.11 is compatible with Play 2.5+.
 
 ### Usage
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,16 +2,12 @@ import com.typesafe.sbt.SbtGit.{GitKeys => git}
 import sbtbuildinfo.BuildInfoPlugin.autoImport._
 import sbtcrossproject.CrossPlugin.autoImport.{CrossType, crossProject}
 
-lazy val theScalaVersion = "2.12.8"
-
-/*
-  2.13.0-RC2 support is currently defined as a separate project (scala_2_13) for convenience while
-  integration libraries are still gaining 2.13 support
- */
-lazy val scalaVersions           = Seq(theScalaVersion, "2.10.7", "2.11.12")
-lazy val scalaVersionsAbove_2_11 = Seq("2.11.12", "2.12.8")
+lazy val scala_2_11Version       = "2.11.12"
+lazy val scala_2_12Version       = "2.12.10"
 lazy val scala_2_13Version       = "2.13.1"
-lazy val scalaVersionsAll        = scalaVersions :+ scala_2_13Version
+lazy val scalaVersionsAll        = Seq(scala_2_11Version, scala_2_12Version, scala_2_13Version)
+
+lazy val theScalaVersion = scala_2_12Version
 
 lazy val scalaTestVersion  = "3.0.8"
 lazy val scalacheckVersion = "1.14.0"
@@ -25,7 +21,7 @@ lazy val quillVersion         = "3.5.0"
 def theDoobieVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, scalaMajor)) if scalaMajor >= 12 => "0.8.8"
-    case Some((2, scalaMajor)) if scalaMajor <= 11 => "0.7.0"
+    case Some((2, scalaMajor)) if scalaMajor == 11 => "0.7.0"
     case _ =>
       throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
   }
@@ -33,7 +29,6 @@ def theDoobieVersion(scalaVersion: String) =
 def theArgonautVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, scalaMajor)) if scalaMajor >= 11 => "6.2.3"
-    case Some((2, scalaMajor)) if scalaMajor == 10 => "6.2.2"
     case _ =>
       throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
   }
@@ -42,7 +37,6 @@ def thePlayVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, scalaMajor)) if scalaMajor >= 13 => "2.8.0"
     case Some((2, scalaMajor)) if scalaMajor >= 11 => "2.7.0"
-    case Some((2, scalaMajor)) if scalaMajor == 10 => "2.4.11"
     case _ =>
       throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
   }
@@ -50,7 +44,6 @@ def thePlayVersion(scalaVersion: String) =
 def theSlickVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, scalaMajor)) if scalaMajor >= 11 => "3.3.2"
-    case Some((2, scalaMajor)) if scalaMajor == 10 => "3.1.1"
     case _ =>
       throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
   }
@@ -58,7 +51,6 @@ def theSlickVersion(scalaVersion: String) =
 def theCatsVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, scalaMajor)) if scalaMajor >= 11 => "2.0.0"
-    case Some((2, scalaMajor)) if scalaMajor == 10 => "1.2.0"
     case _ =>
       throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
   }
@@ -67,7 +59,6 @@ def thePlayJsonVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, scalaMajor)) if scalaMajor >= 13 => "2.8.1"
     case Some((2, scalaMajor)) if scalaMajor >= 11 => "2.7.3"
-    case Some((2, scalaMajor)) if scalaMajor == 10 => "2.4.11"
     case _ =>
       throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
   }
@@ -76,7 +67,6 @@ def theCirceVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, scalaMajor)) if scalaMajor >= 12 => "0.12.1"
     case Some((2, scalaMajor)) if scalaMajor >= 11 => "0.11.1"
-    case Some((2, scalaMajor)) if scalaMajor == 10 => "0.9.3"
     case _ =>
       throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
   }
@@ -86,20 +76,8 @@ def scalaTestPlay(scalaVersion: String) = CrossVersion.partialVersion(scalaVersi
     "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test
   case Some((2, scalaMajor)) if scalaMajor >= 11 =>
     "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % Test
-  case Some((2, scalaMajor)) if scalaMajor == 10 =>
-    "org.scalatestplus" %% "play" % "1.4.0" % Test
   case _ =>
     throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")
-}
-
-/** Temporary fix for Play 5.0.0-M1. */
-def akkaHttp(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
-  case Some((2, scalaMajor)) if scalaMajor >= 13 =>
-    Seq(
-      ("com.typesafe.play" %% "play-akka-http-server" % thePlayVersion(scalaVersion)) excludeAll ("com.typesafe.akka" %% "akka-http-core"),
-      "com.typesafe.akka"  %% "akka-http-core"        % "10.1.8"
-    )
-  case _ => Seq.empty
 }
 
 lazy val baseProjectRefs =
@@ -182,7 +160,6 @@ lazy val macros = crossProject(JSPlatform, JVMPlatform)
   .settings(testSettings: _*)
   .settings(commonWithPublishSettings: _*)
   .settings(withCompatUnmanagedSources(jsJvmCrossProject = true,
-                                       include_210Dir = true,
                                        includeTestSrcs = false): _*)
   .settings(
     name := "enumeratum-macros",
@@ -263,7 +240,7 @@ lazy val enumeratumReactiveMongoBson =
     .settings(testSettings: _*)
     .settings(
       version := "1.5.16-SNAPSHOT",
-      crossScalaVersions := scalaVersionsAbove_2_11 :+ scala_2_13Version,
+      crossScalaVersions := scalaVersionsAll,
       libraryDependencies ++= Seq(
         "org.reactivemongo" %% "reactivemongo"   % reactiveMongoVersion,
         "com.beachape"      %% "enumeratum"      % Versions.Core.stable,
@@ -273,15 +250,7 @@ lazy val enumeratumReactiveMongoBson =
 
 lazy val playJsonAggregate =
   aggregateProject("play-json", enumeratumPlayJsonJs, enumeratumPlayJsonJvm).settings(
-    crossScalaVersions := {
-      val versions = {
-        if (ScalaJSPlugin.autoImport.jsDependencies.?.value.isDefined)
-          post210Only(scalaVersionsAll)
-        else
-          scalaVersionsAll
-      }
-      versions
-    }
+    crossScalaVersions := scalaVersionsAll
   )
 lazy val enumeratumPlayJson = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)
@@ -291,15 +260,7 @@ lazy val enumeratumPlayJson = crossProject(JSPlatform, JVMPlatform)
   .settings(
     name := "enumeratum-play-json",
     version := s"1.5.17-SNAPSHOT",
-    crossScalaVersions := {
-      val versions = {
-        if (ScalaJSPlugin.autoImport.jsDependencies.?.value.isDefined)
-          post210Only(scalaVersionsAll)
-        else
-          scalaVersionsAll
-      }
-      versions
-    },
+    crossScalaVersions := scalaVersionsAll,
     libraryDependencies ++= {
       Seq(
         "com.typesafe.play" %%% "play-json"       % thePlayJsonVersion(scalaVersion.value),
@@ -317,7 +278,7 @@ lazy val enumeratumPlay = Project(id = "enumeratum-play", base = file("enumeratu
   .settings(
     version := s"1.5.17-SNAPSHOT",
     crossScalaVersions := scalaVersionsAll,
-    libraryDependencies ++= akkaHttp(scalaVersion.value) ++ // Temporary fix for Play 5.0.0-M1
+    libraryDependencies ++=
       Seq(
         "com.typesafe.play" %% "play"            % thePlayVersion(scalaVersion.value),
         "com.beachape"      %% "enumeratum"      % Versions.Core.stable,
@@ -326,7 +287,6 @@ lazy val enumeratumPlay = Project(id = "enumeratum-play", base = file("enumeratu
       )
   )
   .settings(withCompatUnmanagedSources(jsJvmCrossProject = false,
-                                       include_210Dir = true,
                                        includeTestSrcs = true): _*)
   .dependsOn(enumeratumPlayJsonJvm % "compile->compile;test->test")
 
@@ -411,7 +371,7 @@ lazy val enumeratumScalacheckJs  = enumeratumScalacheck.js
 lazy val enumeratumScalacheckJvm = enumeratumScalacheck.jvm
 
 lazy val quillAggregate = aggregateProject("quill", enumeratumQuillJs, enumeratumQuillJvm).settings(
-  crossScalaVersions := post210Only(scalaVersionsAbove_2_11 :+ scala_2_13Version)
+  crossScalaVersions := scalaVersionsAll
 )
 lazy val enumeratumQuill = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)
@@ -421,7 +381,7 @@ lazy val enumeratumQuill = crossProject(JSPlatform, JVMPlatform)
   .settings(
     name := "enumeratum-quill",
     version := "1.5.16-SNAPSHOT",
-    crossScalaVersions := post210Only(scalaVersionsAbove_2_11 :+ scala_2_13Version),
+    crossScalaVersions := scalaVersionsAll,
     libraryDependencies ++= {
       Seq(
         "com.beachape" %%% "enumeratum" % Versions.Core.stable,
@@ -446,7 +406,7 @@ lazy val enumeratumDoobie =
     .settings(commonWithPublishSettings: _*)
     .settings(testSettings: _*)
     .settings(
-      crossScalaVersions := scalaVersionsAbove_2_11 :+ scala_2_13Version,
+      crossScalaVersions := scalaVersionsAll,
       version := "1.5.18-SNAPSHOT",
       libraryDependencies ++= {
         Seq(
@@ -494,7 +454,7 @@ lazy val commonSettings = Seq(
   organization := "com.beachape",
   scalafmtOnCompile := true,
   scalaVersion := theScalaVersion,
-  crossScalaVersions := scalaVersions
+  crossScalaVersions := scalaVersionsAll
 ) ++
   compilerSettings ++
   resolverSettings ++
@@ -632,7 +592,6 @@ lazy val benchmarking =
   * Helper function to add unmanaged source compat directories for different scala versions
   */
 def withCompatUnmanagedSources(jsJvmCrossProject: Boolean,
-                               include_210Dir: Boolean,
                                includeTestSrcs: Boolean): Seq[Setting[_]] = {
   def compatDirs(projectbase: File, scalaVersion: String, isMain: Boolean) = {
     val base = if (jsJvmCrossProject) projectbase / ".." else projectbase
@@ -642,9 +601,6 @@ def withCompatUnmanagedSources(jsJvmCrossProject: Boolean,
           .map(_.getCanonicalFile)
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>
         Seq(base / "compat" / "src" / (if (isMain) "main" else "test") / "scala-2.11")
-          .map(_.getCanonicalFile)
-      case Some((2, scalaMajor)) if scalaMajor == 10 && include_210Dir =>
-        Seq(base / "compat" / "src" / (if (isMain) "main" else "test") / "scala-2.10")
           .map(_.getCanonicalFile)
       case _ => Nil
     }
@@ -674,13 +630,13 @@ def withCompatUnmanagedSources(jsJvmCrossProject: Boolean,
   * Assumes that
   *
   *   - a corresponding directory exists under ./aggregates.
-  *   - publishing 2.10.x, 2.11.x, 2.12.x
+  *   - publishing 2.11.x, 2.12.x, 2.13.x
   */
 def aggregateProject(id: String, projects: ProjectReference*): Project =
   Project(id = s"$id-aggregate", base = file(s"./aggregates/$id"))
     .settings(commonWithPublishSettings: _*)
     .settings(
-      crossScalaVersions := scalaVersions,
+      crossScalaVersions := scalaVersionsAll,
       crossVersion := CrossVersion.binary,
       // Do not publish the aggregate project (it just serves as an aggregate)
       libraryDependencies += {
@@ -690,11 +646,3 @@ def aggregateProject(id: String, projects: ProjectReference*): Project =
       publishLocal := {}
     )
     .aggregate(projects: _*)
-
-def post210Only(versions: Seq[String]): Seq[String] =
-  versions.filter { vString =>
-    CrossVersion.partialVersion(vString) match {
-      case Some((major, minor)) if major >= 2 && minor >= 11 => true
-      case _                                                 => false
-    }
-  }

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ def theArgonautVersion(scalaVersion: String) =
 
 def thePlayVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
-    case Some((2, scalaMajor)) if scalaMajor >= 13 => "2.7.3"
+    case Some((2, scalaMajor)) if scalaMajor >= 13 => "2.8.0"
     case Some((2, scalaMajor)) if scalaMajor >= 11 => "2.7.0"
     case Some((2, scalaMajor)) if scalaMajor == 10 => "2.4.11"
     case _ =>
@@ -65,7 +65,7 @@ def theCatsVersion(scalaVersion: String) =
 
 def thePlayJsonVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
-    case Some((2, scalaMajor)) if scalaMajor >= 13 => "2.7.4"
+    case Some((2, scalaMajor)) if scalaMajor >= 13 => "2.8.1"
     case Some((2, scalaMajor)) if scalaMajor >= 11 => "2.7.3"
     case Some((2, scalaMajor)) if scalaMajor == 10 => "2.4.11"
     case _ =>
@@ -82,6 +82,8 @@ def theCirceVersion(scalaVersion: String) =
   }
 
 def scalaTestPlay(scalaVersion: String) = CrossVersion.partialVersion(scalaVersion) match {
+  case Some((2, scalaMajor)) if scalaMajor >= 13 =>
+    "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test
   case Some((2, scalaMajor)) if scalaMajor >= 11 =>
     "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.3" % Test
   case Some((2, scalaMajor)) if scalaMajor == 10 =>

--- a/build.sbt
+++ b/build.sbt
@@ -2,10 +2,10 @@ import com.typesafe.sbt.SbtGit.{GitKeys => git}
 import sbtbuildinfo.BuildInfoPlugin.autoImport._
 import sbtcrossproject.CrossPlugin.autoImport.{CrossType, crossProject}
 
-lazy val scala_2_11Version       = "2.11.12"
-lazy val scala_2_12Version       = "2.12.10"
-lazy val scala_2_13Version       = "2.13.1"
-lazy val scalaVersionsAll        = Seq(scala_2_11Version, scala_2_12Version, scala_2_13Version)
+lazy val scala_2_11Version = "2.11.12"
+lazy val scala_2_12Version = "2.12.10"
+lazy val scala_2_13Version = "2.13.1"
+lazy val scalaVersionsAll  = Seq(scala_2_11Version, scala_2_12Version, scala_2_13Version)
 
 lazy val theScalaVersion = scala_2_12Version
 
@@ -159,8 +159,7 @@ lazy val macros = crossProject(JSPlatform, JVMPlatform)
   .in(file("macros"))
   .settings(testSettings: _*)
   .settings(commonWithPublishSettings: _*)
-  .settings(withCompatUnmanagedSources(jsJvmCrossProject = true,
-                                       includeTestSrcs = false): _*)
+  .settings(withCompatUnmanagedSources(jsJvmCrossProject = true, includeTestSrcs = false): _*)
   .settings(
     name := "enumeratum-macros",
     version := Versions.Macros.head,
@@ -286,8 +285,7 @@ lazy val enumeratumPlay = Project(id = "enumeratum-play", base = file("enumeratu
         scalaTestPlay(scalaVersion.value)
       )
   )
-  .settings(withCompatUnmanagedSources(jsJvmCrossProject = false,
-                                       includeTestSrcs = true): _*)
+  .settings(withCompatUnmanagedSources(jsJvmCrossProject = false, includeTestSrcs = true): _*)
   .dependsOn(enumeratumPlayJsonJvm % "compile->compile;test->test")
 
 lazy val circeAggregate = aggregateProject("circe", enumeratumCirceJs, enumeratumCirceJvm)

--- a/enumeratum-play-json/src/main/scala/enumeratum/PlayJsonEnum.scala
+++ b/enumeratum-play-json/src/main/scala/enumeratum/PlayJsonEnum.scala
@@ -1,7 +1,8 @@
 package enumeratum
 
-import play.api.libs.json.Format
+import play.api.libs.json.{Format, Writes}
 
 trait PlayJsonEnum[A <: EnumEntry] { self: Enum[A] =>
-  implicit val jsonFormat: Format[A] = EnumFormats.formats(this)
+  implicit val jsonFormat: Format[A]               = EnumFormats.formats(this)
+  implicit def contraJsonWrites[B <: A]: Writes[B] = jsonFormat.contramap[B](b => b: A)
 }

--- a/publish-integration-libs
+++ b/publish-integration-libs
@@ -7,9 +7,7 @@ say "Done 1" &&
 say "Done 2" &&
 sbt "project enumeratum-reactivemongo-bson" +clean +publishSigned &&
 say "Done 3" &&
-# sbt "project play-json-aggregate" +clean +publishSigned && # Doesn't work; 2.10 tries to publish a 2.13 POM
-sbt "project enumeratumPlayJsonJVM" +clean +publishSigned &&
-sbt "project enumeratumPlayJsonJS" +clean +publishSigned &&
+sbt "project play-json-aggregate" +clean +publishSigned &&
 say "Done 4" &&
 sbt "project enumeratum-play" +clean +publishSigned &&
 say "Done 5" &&


### PR DESCRIPTION
In play-json `2.8.x`, the writes trait was [changed](https://github.com/playframework/play-json/pull/216) from `Writes[-T]` (contravariant) to `Writes[T]` (invariant) which breaks enumeratum's `PlayJsonEnum` trait. This PR does the following:

- Adds an implicit helper to contraMap the `Writes` provided by the existing trait. This seems to be sufficient enough to support play-json `2.8.x` without any more complicated code changes.
- Drops Scala 2.10 support. While working on this PR there were a few sporadic dependency resolution issues with resolving 2.10 based dependencies, but now I'm unable to resolve any of the 2.10 dependencies when building the project, so I've elected to drop 2.10 support with this PR.
- Cleans up `build.sbt` now that it seems like Scala 2.13 is supported on all projects.