### PR TITLE
CamelCase enum should be recognized

### DIFF
--- a/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
@@ -101,7 +101,7 @@ object EnumEntry {
     override def entryName: String = stableEntryName
 
     private[this] lazy val stableEntryName: String =
-      super.entryName.split("_+").map(s => capitalise(s.toLowerCase)).mkString
+      camel2WordArray(super.entryName).map(s => capitalise(s.toLowerCase)).mkString
   }
 
   /**

--- a/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
@@ -384,6 +384,7 @@ class EnumSpec extends FunSpec with Matchers {
         CamelcaseEnum.withName("GoodBye") shouldBe CamelcaseEnum.GOOD_BYE
         CamelcaseEnum.withName("sikeagain") shouldBe CamelcaseEnum.SIKE_AGAIN
         CamelcaseEnum.withName("Private") shouldBe CamelcaseEnum._PRIVATE
+        CamelcaseEnum.withName("CamelCase") shouldBe CamelcaseEnum.CamelCase
 
         LowerCamelcaseEnum.withName("hello") shouldBe LowerCamelcaseEnum.HELLO
         LowerCamelcaseEnum.withName("goodBye") shouldBe LowerCamelcaseEnum.GOOD_BYE

--- a/enumeratum-core/src/test/scala/enumeratum/Models.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/Models.scala
@@ -198,6 +198,7 @@ object CamelcaseEnum extends Enum[CamelcaseEnum] {
   case object GOOD_BYE   extends CamelcaseEnum
   case object SIKE_AGAIN extends CamelcaseEnum with Lowercase
   case object _PRIVATE   extends CamelcaseEnum
+  case object CamelCase  extends CamelcaseEnum
 
 }
 


### PR DESCRIPTION
Hi, I've found a bug where `CamelCase` like enumeration is recognized as `Camelcase` instead of `CamelCase`
This should hopefully fixes that problem.
I have added some test along with this