### PR TITLE
Find members in nested objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,36 @@ Greeting.withNameLowercaseOnlyOption("hello")
 Note that by default, `findValues` will return a `Seq` with the enum members listed in written-order (relevant if you want to
 use the `indexOf` method).
 
+Enum members found in nested objects will be included by `findValues` as well, and will appear in the order they are
+written in the companion object, top to bottom. Note that enum members declared in traits or classes will *not* be
+discovered by `findValues`. For example:
+
+```scala
+sealed trait Nesting extends EnumEntry
+object Nesting extends Enum[Nesting] {
+  val values = findValues
+
+  case object Hello extends Nesting
+  object others {
+    case object GoodBye extends Nesting
+  }
+  case object Hi extends Nesting
+  class InnerClass {
+    case object NotFound extends Nesting
+  }
+}
+
+Nesting.values
+// => res0: scala.collection.immutable.IndexedSeq[Nesting] = Vector(Hello, GoodBye, Hi)
+```
+
 For an interactive demo, checkout this [Scastie snippet](https://scastie.scala-lang.org/lloydmeta/AMXiGvzkR0CD5sgWXiW4bg).
 
 ## More examples
 
 ### Enum
 
-Continuing from the enum declared in [the quick-start section](#usage):
+Continuing from the `Greeting` enum declared in [the quick-start section](#usage):
 
 ```scala
 import Greeting._
@@ -1140,7 +1163,7 @@ CREATE TABLE clothes (
   shirt varchar(100)
 )
 ```
-you should use following code 
+you should use following code
 ```scala
 import enumeratum._
 

--- a/build.sbt
+++ b/build.sbt
@@ -185,7 +185,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     crossScalaVersions := scalaVersionsAll,
     // libraryDependencies += "com.beachape" %% "enumeratum-macros" % Versions.Macros.stable
   )
- .dependsOn(macros) // used for testing macros
+  .dependsOn(macros) // used for testing macros
 lazy val coreJS  = core.js
 lazy val coreJVM = core.jvm
 

--- a/build.sbt
+++ b/build.sbt
@@ -183,9 +183,9 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     name := "enumeratum",
     version := Versions.Core.head,
     crossScalaVersions := scalaVersionsAll,
-    libraryDependencies += "com.beachape" %% "enumeratum-macros" % Versions.Macros.stable
+    // libraryDependencies += "com.beachape" %% "enumeratum-macros" % Versions.Macros.stable
   )
-//  .dependsOn(macros) // used for testing macros
+ .dependsOn(macros) // used for testing macros
 lazy val coreJS  = core.js
 lazy val coreJVM = core.jvm
 

--- a/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
@@ -33,7 +33,9 @@ class EnumSpec extends FunSpec with Matchers {
             NestedObjectEnum.nested1.GoodBye.NestedInsideMember,
             NestedObjectEnum.nested2.Hello,
             NestedObjectEnum.nested2.GoodBye,
-            NestedObjectEnum.nested2.nested3.Hello
+            NestedObjectEnum.nested2.nested3.Hello,
+            NestedObjectEnum.BackToRoot,
+            NestedObjectEnum.nested4.NestedAgain
           ))
       }
 
@@ -435,6 +437,17 @@ class EnumSpec extends FunSpec with Matchers {
       SmartEnum.indexOf(SmartEnum.Hello) shouldBe 0
       SmartEnum.indexOf(SmartEnum.GoodBye) shouldBe 1
       SmartEnum.indexOf(SmartEnum.Hi) shouldBe 2
+
+      NestedObjectEnum.indexOf(NestedObjectEnum.Hello) shouldBe 0
+      NestedObjectEnum.indexOf(NestedObjectEnum.GoodBye) shouldBe 1
+      NestedObjectEnum.indexOf(NestedObjectEnum.nested1.Hello) shouldBe 2
+      NestedObjectEnum.indexOf(NestedObjectEnum.nested1.GoodBye) shouldBe 3
+      NestedObjectEnum.indexOf(NestedObjectEnum.nested1.GoodBye.NestedInsideMember) shouldBe 4
+      NestedObjectEnum.indexOf(NestedObjectEnum.nested2.Hello) shouldBe 5
+      NestedObjectEnum.indexOf(NestedObjectEnum.nested2.GoodBye) shouldBe 6
+      NestedObjectEnum.indexOf(NestedObjectEnum.nested2.nested3.Hello) shouldBe 7
+      NestedObjectEnum.indexOf(NestedObjectEnum.BackToRoot) shouldBe 8
+      NestedObjectEnum.indexOf(NestedObjectEnum.nested4.NestedAgain) shouldBe 9
     }
 
     it("should return -1 for elements that do not exist") {

--- a/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
@@ -23,6 +23,20 @@ class EnumSpec extends FunSpec with Matchers {
         DummyEnum.values should be(IndexedSeq(Hello, GoodBye, Hi))
       }
 
+      it("should contain objects found in nested objects") {
+        NestedObjectEnum.values should be(
+          IndexedSeq(
+            NestedObjectEnum.Hello,
+            NestedObjectEnum.GoodBye,
+            NestedObjectEnum.nested1.Hello,
+            NestedObjectEnum.nested1.GoodBye,
+            NestedObjectEnum.nested1.GoodBye.NestedInsideMember,
+            NestedObjectEnum.nested2.Hello,
+            NestedObjectEnum.nested2.GoodBye,
+            NestedObjectEnum.nested2.nested3.Hello
+          ))
+      }
+
     }
 
     describe("#withName") {

--- a/enumeratum-core/src/test/scala/enumeratum/Models.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/Models.scala
@@ -228,6 +228,33 @@ object UncapitalisedEnum extends Enum[UncapitalisedEnum] {
 
 }
 
+sealed trait NestedObjectEnum extends EnumEntry
+
+object NestedObjectEnum extends Enum[NestedObjectEnum] {
+
+  val values = findValues
+
+  case object Hello   extends NestedObjectEnum
+  case object GoodBye extends NestedObjectEnum
+
+  object nested1 {
+    case object Hello extends NestedObjectEnum
+    case object GoodBye extends NestedObjectEnum {
+      case object NestedInsideMember extends NestedObjectEnum
+    }
+  }
+
+  object nested2 {
+    case object Hello   extends NestedObjectEnum
+    case object GoodBye extends NestedObjectEnum
+
+    object nested3 {
+      case object Hello extends NestedObjectEnum
+    }
+  }
+
+}
+
 sealed class MultiEnum(override val entryName: String, val alternateNames: String*)
     extends EnumEntry
 

--- a/enumeratum-core/src/test/scala/enumeratum/Models.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/Models.scala
@@ -253,6 +253,10 @@ object NestedObjectEnum extends Enum[NestedObjectEnum] {
     }
   }
 
+  class NestedClass {
+    case object NotFound extends NestedObjectEnum
+  }
+
   case object BackToRoot extends NestedObjectEnum
 
   object nested4 {

--- a/enumeratum-core/src/test/scala/enumeratum/Models.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/Models.scala
@@ -253,6 +253,12 @@ object NestedObjectEnum extends Enum[NestedObjectEnum] {
     }
   }
 
+  case object BackToRoot extends NestedObjectEnum
+
+  object nested4 {
+    case object NestedAgain extends NestedObjectEnum
+  }
+
 }
 
 sealed class MultiEnum(override val entryName: String, val alternateNames: String*)


### PR DESCRIPTION
This updates the `findValues` macro to recursively search the bodies of objects defined within the companion object, e.g.

```scala
sealed trait Thing extends EnumEntry
object Thing extends Enum[Thing] {
  object nested {
    // this object is found now
    case object Foo extends Thing

    object nested2 {
      // this is found too
      case object Bar extends Thing {

        // even this one is found
        case object Baz extends Thing
      }
    }
  }
}
```

Note: I expect CI will fail since [build.sbt references the stable version of enumeratum-macros](https://github.com/lloydmeta/enumeratum/blob/master/build.sbt#L186) which doesn't contain these changes. I tested locally by uncommenting the `dependsOn(macros)` line, but figured I shouldn't commit that. Let me know what the right workflow is for getting everything up to date.