### PR TITLE
Play json & Argonaut sjs 1.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Enumeratum is published for Scala 2.11.x, 2.12.x, 2.13.x as well as ScalaJS.
 Integrations are available for:
 
 - [Play](https://www.playframework.com/): JVM only
-- [Play JSON](https://www.playframework.com/documentation/2.5.x/ScalaJson): JVM (included in Play integration but also available separately) and ScalaJS
+- [Play JSON](https://www.playframework.com/documentation/2.8.x/ScalaJson): JVM (included in Play integration but also available separately) and ScalaJS
 - [Circe](https://github.com/travisbrown/circe): JVM and ScalaJS
 - [ReactiveMongo BSON](http://reactivemongo.org/releases/0.1x/documentation/bson/overview.html): JVM only
 - [Argonaut](http://argonaut.io): JVM and ScalaJS
@@ -350,7 +350,7 @@ libraryDependencies ++= Seq(
 )
 ```
 
-Note that as of version 1.4.0, `enumeratum-play` for Scala 2.11 is compatible with Play 2.5+
+Note that as of version 1.4.0, `enumeratum-play` for Scala 2.11 is compatible with Play 2.5 - 2.7
 
 ### Usage
 
@@ -491,7 +491,7 @@ libraryDependencies ++= Seq(
 )
 ```
 
-Note that as of version 1.4.0, `enumeratum-play-json` for Scala 2.11 is compatible with Play 2.5+.
+Note that as of version 1.4.0, `enumeratum-play-json` for Scala 2.11 is compatible with Play 2.5 - 2.7
 
 ### Usage
 

--- a/enumeratum-play-json/src/main/scala/enumeratum/PlayInsensitiveJsonEnum.scala
+++ b/enumeratum-play-json/src/main/scala/enumeratum/PlayInsensitiveJsonEnum.scala
@@ -1,7 +1,8 @@
 package enumeratum
 
-import play.api.libs.json.Format
+import play.api.libs.json.{Format, Writes}
 
 trait PlayInsensitiveJsonEnum[A <: EnumEntry] { self: Enum[A] =>
-  implicit val jsonFormat: Format[A] = EnumFormats.formats(this, insensitive = true)
+  implicit val jsonFormat: Format[A]               = EnumFormats.formats(this, insensitive = true)
+  implicit def contraJsonWrites[B <: A]: Writes[B] = jsonFormat.contramap[B](b => b: A)
 }

--- a/enumeratum-play-json/src/main/scala/enumeratum/PlayLowercaseJsonEnum.scala
+++ b/enumeratum-play-json/src/main/scala/enumeratum/PlayLowercaseJsonEnum.scala
@@ -1,7 +1,8 @@
 package enumeratum
 
-import play.api.libs.json.Format
+import play.api.libs.json.{Format, Writes}
 
 trait PlayLowercaseJsonEnum[A <: EnumEntry] { self: Enum[A] =>
-  implicit val jsonFormat: Format[A] = EnumFormats.formatsLowerCaseOnly(this)
+  implicit val jsonFormat: Format[A]               = EnumFormats.formatsLowerCaseOnly(this)
+  implicit def contraJsonWrites[B <: A]: Writes[B] = jsonFormat.contramap[B](b => b: A)
 }

--- a/enumeratum-play-json/src/main/scala/enumeratum/PlayUppercaseJsonEnum.scala
+++ b/enumeratum-play-json/src/main/scala/enumeratum/PlayUppercaseJsonEnum.scala
@@ -1,7 +1,8 @@
 package enumeratum
 
-import play.api.libs.json.Format
+import play.api.libs.json.{Format, Writes}
 
 trait PlayUppercaseJsonEnum[A <: EnumEntry] { self: Enum[A] =>
-  implicit val jsonFormat: Format[A] = EnumFormats.formatsUppercaseOnly(this)
+  implicit val jsonFormat: Format[A]               = EnumFormats.formatsUppercaseOnly(this)
+  implicit def contraJsonWrites[B <: A]: Writes[B] = jsonFormat.contramap[B](b => b: A)
 }

--- a/enumeratum-play-json/src/test/scala/enumeratum/Dummy.scala
+++ b/enumeratum-play-json/src/test/scala/enumeratum/Dummy.scala
@@ -23,3 +23,19 @@ object InsensitiveDummy
   case object c extends InsensitiveDummy
   val values = findValues
 }
+
+sealed trait LowercaseDummy extends EnumEntry
+object LowercaseDummy extends Enum[LowercaseDummy] with PlayLowercaseJsonEnum[LowercaseDummy] {
+  case object Apple  extends LowercaseDummy
+  case object Banana extends LowercaseDummy
+  case object Cherry extends LowercaseDummy
+  val values = findValues
+}
+
+sealed trait UppercaseDummy extends EnumEntry
+object UppercaseDummy extends Enum[UppercaseDummy] with PlayUppercaseJsonEnum[UppercaseDummy] {
+  case object Apple  extends UppercaseDummy
+  case object Banana extends UppercaseDummy
+  case object Cherry extends UppercaseDummy
+  val values = findValues
+}

--- a/enumeratum-play-json/src/test/scala/enumeratum/EnumFormatsSpec.scala
+++ b/enumeratum-play-json/src/test/scala/enumeratum/EnumFormatsSpec.scala
@@ -1,10 +1,11 @@
 package enumeratum
 
 import org.scalatest.OptionValues._
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
 
-class EnumFormatsSpec extends FunSpec with Matchers {
+class EnumFormatsSpec extends AnyFunSpec with Matchers {
 
   testScenario(
     descriptor = "normal operation",

--- a/enumeratum-play-json/src/test/scala/enumeratum/PlayJsonEnumSpec.scala
+++ b/enumeratum-play-json/src/test/scala/enumeratum/PlayJsonEnumSpec.scala
@@ -1,37 +1,53 @@
 package enumeratum
 
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.{JsNumber, JsString, Json => PlayJson}
 import org.scalatest.OptionValues._
 
-class PlayJsonEnumSpec extends FunSpec with Matchers {
+class PlayJsonEnumSpec extends AnyFunSpec with Matchers {
 
   describe("JSON serdes") {
 
-    describe("sensitive deserialisation") {
+    describe("deserialisation") {
 
-      it("should work with valid values") {
-        JsString("A").asOpt[Dummy].value shouldBe Dummy.A
+      describe("case sensitive") {
+        it("should work with valid values") {
+          JsString("A").asOpt[Dummy].value shouldBe Dummy.A
+          JsString("c").asOpt[Dummy].value shouldBe Dummy.c
+
+          JsString("apple").asOpt[LowercaseDummy].value shouldBe LowercaseDummy.Apple
+          JsString("cherry").asOpt[LowercaseDummy].value shouldBe LowercaseDummy.Cherry
+
+          JsString("APPLE").asOpt[UppercaseDummy].value shouldBe UppercaseDummy.Apple
+          JsString("CHERRY").asOpt[UppercaseDummy].value shouldBe UppercaseDummy.Cherry
+        }
+
+        it("should fail with invalid values") {
+          JsString("a").asOpt[Dummy] shouldBe None
+          JsString("C").asOpt[Dummy] shouldBe None
+          JsString("D").asOpt[Dummy] shouldBe None
+          JsNumber(2).asOpt[Dummy] shouldBe None
+
+          JsString("Apple").asOpt[LowercaseDummy] shouldBe None
+          JsString("Cherry").asOpt[LowercaseDummy] shouldBe None
+
+          JsString("apple").asOpt[UppercaseDummy] shouldBe None
+          JsString("cherry").asOpt[UppercaseDummy] shouldBe None
+        }
       }
 
-      it("should fail with invalid values") {
-        JsString("a").asOpt[Dummy] shouldBe None
-        JsString("D").asOpt[Dummy] shouldBe None
-        JsNumber(2).asOpt[Dummy] shouldBe None
-      }
-    }
+      describe("case in-sensitive") {
+        it("should work with valid values") {
+          JsString("A").asOpt[InsensitiveDummy].value shouldBe InsensitiveDummy.A
+          JsString("a").asOpt[InsensitiveDummy].value shouldBe InsensitiveDummy.A
+        }
 
-    describe("in-sensitive deserialisation") {
-
-      it("should work with valid values") {
-        JsString("A").asOpt[InsensitiveDummy].value shouldBe InsensitiveDummy.A
-        JsString("a").asOpt[InsensitiveDummy].value shouldBe InsensitiveDummy.A
-      }
-
-      it("should fail with invalid values") {
-        JsString("d").asOpt[InsensitiveDummy] shouldBe None
-        JsString("D").asOpt[InsensitiveDummy] shouldBe None
-        JsNumber(2).asOpt[Dummy] shouldBe None
+        it("should fail with invalid values") {
+          JsString("d").asOpt[InsensitiveDummy] shouldBe None
+          JsString("D").asOpt[InsensitiveDummy] shouldBe None
+          JsNumber(2).asOpt[Dummy] shouldBe None
+        }
       }
     }
 
@@ -39,6 +55,9 @@ class PlayJsonEnumSpec extends FunSpec with Matchers {
 
       it("should serialise values to JsString") {
         PlayJson.toJson(Dummy.A) shouldBe JsString("A")
+        PlayJson.toJson(InsensitiveDummy.A) shouldBe JsString("A")
+        PlayJson.toJson(LowercaseDummy.Apple) shouldBe JsString("apple")
+        PlayJson.toJson(UppercaseDummy.Apple) shouldBe JsString("APPLE")
       }
 
     }

--- a/enumeratum-play-json/src/test/scala/enumeratum/values/EnumFormatsSpec.scala
+++ b/enumeratum-play-json/src/test/scala/enumeratum/values/EnumFormatsSpec.scala
@@ -1,6 +1,7 @@
 package enumeratum.values
 
-import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import EnumFormats._
 import play.api.libs.json.{JsNumber, JsString}
 
@@ -9,7 +10,7 @@ import play.api.libs.json.{JsNumber, JsString}
   *
   * Copyright 2016
   */
-class EnumFormatsSpec extends FunSpec with Matchers with EnumJsonFormatHelpers {
+class EnumFormatsSpec extends AnyFunSpec with Matchers with EnumJsonFormatHelpers {
 
   describe(".reads") {
 

--- a/enumeratum-play-json/src/test/scala/enumeratum/values/EnumJsonFormatHelpers.scala
+++ b/enumeratum-play-json/src/test/scala/enumeratum/values/EnumJsonFormatHelpers.scala
@@ -1,6 +1,7 @@
 package enumeratum.values
 
-import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
 import org.scalatest.OptionValues._
 
@@ -9,7 +10,7 @@ import org.scalatest.OptionValues._
   *
   * Copyright 2016
   */
-trait EnumJsonFormatHelpers { this: FunSpec with Matchers =>
+trait EnumJsonFormatHelpers { this: AnyFunSpec with Matchers =>
 
   def testNumericWrites[EntryType <: ValueEnumEntry[ValueType],
                         ValueType <: AnyVal: Numeric: Writes](


### PR DESCRIPTION
## Purpose

+ Reinstates play-json js project
  - scala `2.12.x` and `2.13.x` => `2.9.0`
  - scala `2.11.x` => js still not supported (and unlikely in the future)
+ Reinstates argonaut js project
  - scala `2.12.x` and `2.13.x` => `6.3.0`
  - scala `2.11.x` => `6.2.5`
+ Fixes regression (#279) introduced in (#269)
  - Test cases added in play-json module that would have caught the regression
+ Bumps play to `2.8.0` for scala `2.12.x` and `2.13.x`