### PR TITLE
Initialization-order problem example.

### DIFF
--- a/enumeratum-core/src/test/scala/enumeratum/values/State.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/values/State.scala
@@ -1,0 +1,13 @@
+package enumeratum.values
+
+import enumeratum._
+
+sealed abstract class State(override val entryName: String) extends EnumEntry
+
+object State extends Enum[State] {
+
+  val values = findValues
+
+  case object Alabama extends State("AL")
+  case object Alaska  extends State("AK")
+}

--- a/enumeratum-core/src/test/scala/enumeratum/values/StateFailed.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/values/StateFailed.scala
@@ -1,0 +1,18 @@
+package enumeratum.values
+
+import enumeratum._
+
+sealed abstract class StateFailed(override val entryName: String) extends EnumEntry
+
+object StateFailed extends Enum[StateFailed] {
+
+  val values = findValues // <- OK if replaced with lazy val
+
+  val ALABAMA = "AL" // <- OK if replaced with final val
+  val ALASKA = "AK" // <- OK if replaced with final val
+
+  case object Alabama extends StateFailed(ALABAMA)
+  case object Alaska  extends StateFailed(ALASKA)
+
+  // val values = findValues // <- OK if moved here
+}

--- a/enumeratum-core/src/test/scala/enumeratum/values/StateFailedTest.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/values/StateFailedTest.scala
@@ -1,0 +1,20 @@
+package enumeratum.values
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+class StateFailedTest extends AnyFlatSpec {
+
+  "StateFailed" should "return a correct entry name" in {
+
+    val inputList =
+      List(StateFailed.Alaska, StateFailed.Alabama)
+    val outputList = List("AK", "AL")
+
+    for ((input, expected) <- inputList.zip(outputList)) {
+      val result = input.entryName
+      assert(result == expected, f"for input {$input}")
+    }
+
+  }
+
+}

--- a/enumeratum-core/src/test/scala/enumeratum/values/StateTest.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/values/StateTest.scala
@@ -1,0 +1,20 @@
+package enumeratum.values
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+class StateTest extends AnyFlatSpec {
+
+  "State" should "return a correct entry name" in {
+
+    val inputList =
+      List(State.Alaska, State.Alabama)
+    val outputList = List("AK", "AL")
+
+    for ((input, expected) <- inputList.zip(outputList)) {
+      val result = input.entryName
+      assert(result == expected, f"for input {$input}")
+    }
+
+  }
+
+}


### PR DESCRIPTION
Attempt to define a problem with a failed unit-test.
I am not sure if anything can be fixed in enumeratum code.

The problem is defined in [Scala FAQ: "Why is my abstract or overridden val null?"](https://docs.scala-lang.org/tutorials/FAQ/initialization-order.html)