### PR TITLE
bump doobie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ dist
 /.settings
 .bsp
 .bloop
+.metals/
+.vscode/
 metals.sbt
 
 #OSX

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ lazy val quillVersion         = "3.7.1"
 
 def theDoobieVersion(scalaVersion: String) =
   CrossVersion.partialVersion(scalaVersion) match {
-    case Some((2, scalaMajor)) if scalaMajor >= 12 => "0.13.4"
+    case Some((2, scalaMajor)) if scalaMajor >= 12 => "1.0.0-RC2"
     case Some((2, scalaMajor)) if scalaMajor == 11 => "0.7.1"
     case _ =>
       throw new IllegalArgumentException(s"Unsupported Scala version $scalaVersion")


### PR DESCRIPTION
This is just what the title says.
Doobie 1.0.0-RC1 is compatible with 0.13.4, but sbt complains when doobie 1.0.0-RC2 and enumeratum-doobie are used together.
In our project, setting an exclusion rule works, but it would be nice to have an out of the box working version.
I don't know what you policy about release candidates is, but I also believe that many users are on the RC.
Many thanks!