### PR TITLE
make wrapped value private in EnumEntryOps

### DIFF
--- a/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
+++ b/enumeratum-core/src/main/scala/enumeratum/EnumEntry.scala
@@ -160,7 +160,7 @@ object EnumEntry {
 
   /** Helper implicit class that holds enrichment methods
     */
-  implicit class EnumEntryOps[A <: EnumEntry](val enumEntry: A) extends AnyVal {
+  implicit class EnumEntryOps[A <: EnumEntry](private val enumEntry: A) extends AnyVal {
 
     /** Checks if the current enum value is contained by the set of enum values in the parameter
       * list.


### PR DESCRIPTION
Make `enumEntry: A` private to improve ergonomics, because you cannot call `RandomEnumEntry.enumEntry.enumEntry.enumEntry` and so on. Also it's a good practice to make them private.