### PR TITLE
Add ScalikeJDBC support.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -758,6 +758,33 @@ lazy val enumeratumCatsJvm = enumeratumCats.jvm.configure(configureWithLocal(cor
 
 lazy val enumeratumCatsNative = enumeratumCats.native.configure(configureWithLocal(coreNative))
 
+// ScalikeJDBC
+lazy val enumeratumScalikeJDBC =
+  (project in file("enumeratum-scalikejdbc") withId "enumeratum-scalikejdbc")
+    .settings(commonWithPublishSettings)
+    .settings(testSettings)
+    .settings(
+      version := Versions.Core.head,
+      crossScalaVersions := scalaVersionsAll,
+      libraryDependencies ++= Seq(
+        "com.h2database" % "h2" % "1.4.197" % Test,
+        "org.scalikejdbc" %% "scalikejdbc" % "4.0.0",
+        "org.scalikejdbc" %% "scalikejdbc-test" % "4.0.0" % Test
+      ),
+      libraryDependencies ++= {
+        if (useLocalVersion) {
+          Seq.empty
+        } else {
+          Seq("com.beachape" %% "enumeratum" % Versions.Core.stable)
+        }
+      },
+      Test / parallelExecution := false
+    )
+    .settings( // TODO: Remove once Slick is published for Dotty
+      disabledSettings
+    )
+    .configure(configureWithLocal(coreJVM))
+
 lazy val commonSettings = Seq(
   organization       := "com.beachape",
   scalafmtOnCompile  := true,

--- a/enumeratum-scalikejdbc/src/main/scala/enumeratum/ScalikeJDBCEnum.scala
+++ b/enumeratum-scalikejdbc/src/main/scala/enumeratum/ScalikeJDBCEnum.scala
@@ -1,0 +1,23 @@
+package enumeratum
+
+import scalikejdbc.{ParameterBinderFactory, ParameterBinderWithValue, TypeBinder}
+
+import java.sql.PreparedStatement
+
+trait ScalikeJDBCEnum[A <: EnumEntry] extends Enum[A] {
+  implicit val typeBinder: TypeBinder[A] = {
+    TypeBinder.string.map(withName)
+  }
+
+  implicit val optionalTypeBinder: TypeBinder[Option[A]] = {
+    TypeBinder.string.map(withNameOption)
+  }
+
+  implicit val parameterBinderFactory: ParameterBinderFactory[A] = (entry: A) =>
+    new ParameterBinderWithValue() {
+      override def value: A = entry
+      override def apply(stmt: PreparedStatement, idx: Int): Unit = {
+        stmt.setString(idx, value.entryName)
+      }
+    }
+}

--- a/enumeratum-scalikejdbc/src/main/scala/enumeratum/values/ByteScalikeJDBCEnum.scala
+++ b/enumeratum-scalikejdbc/src/main/scala/enumeratum/values/ByteScalikeJDBCEnum.scala
@@ -1,0 +1,23 @@
+package enumeratum.values
+
+import scalikejdbc.{ParameterBinderFactory, ParameterBinderWithValue, TypeBinder}
+
+import java.sql.PreparedStatement
+
+trait ByteScalikeJDBCEnum[A <: ByteEnumEntry] extends ByteEnum[A] {
+  implicit val typeBinder: TypeBinder[A] = {
+    TypeBinder.byte.map(withValue)
+  }
+
+  implicit val optionalTypeBinder: TypeBinder[Option[A]] = {
+    TypeBinder.byte.map(withValueOpt)
+  }
+
+  implicit val parameterBinderFactory: ParameterBinderFactory[A] = (entry: A) =>
+    new ParameterBinderWithValue() {
+      override def value: A = entry
+      override def apply(stmt: PreparedStatement, idx: Int): Unit = {
+        stmt.setByte(idx, value.value)
+      }
+    }
+}

--- a/enumeratum-scalikejdbc/src/main/scala/enumeratum/values/CharScalikeJDBCEnum.scala
+++ b/enumeratum-scalikejdbc/src/main/scala/enumeratum/values/CharScalikeJDBCEnum.scala
@@ -1,0 +1,23 @@
+package enumeratum.values
+
+import scalikejdbc.{ParameterBinderFactory, ParameterBinderWithValue, TypeBinder}
+
+import java.sql.PreparedStatement
+
+trait CharScalikeJDBCEnum[A <: CharEnumEntry] extends CharEnum[A] {
+  implicit val typeBinder: TypeBinder[A] = {
+    TypeBinder.string.map { x => withValue(x.charAt(0)) }
+  }
+
+  implicit val optionalTypeBinder: TypeBinder[Option[A]] = {
+    TypeBinder.string.map(_.headOption.map(withValue))
+  }
+
+  implicit val parameterBinderFactory: ParameterBinderFactory[A] = (entry: A) =>
+    new ParameterBinderWithValue() {
+      override def value: A = entry
+      override def apply(stmt: PreparedStatement, idx: Int): Unit = {
+        stmt.setString(idx, value.value.toString)
+      }
+    }
+}

--- a/enumeratum-scalikejdbc/src/main/scala/enumeratum/values/IntScalikeJDBCEnum.scala
+++ b/enumeratum-scalikejdbc/src/main/scala/enumeratum/values/IntScalikeJDBCEnum.scala
@@ -1,0 +1,23 @@
+package enumeratum.values
+
+import scalikejdbc.{ParameterBinderFactory, ParameterBinderWithValue, TypeBinder}
+
+import java.sql.PreparedStatement
+
+trait IntScalikeJDBCEnum[A <: IntEnumEntry] extends IntEnum[A] {
+  implicit val typeBinder: TypeBinder[A] = {
+    TypeBinder.int.map(withValue)
+  }
+
+  implicit val optionalTypeBinder: TypeBinder[Option[A]] = {
+    TypeBinder.int.map(withValueOpt)
+  }
+
+  implicit val parameterBinderFactory: ParameterBinderFactory[A] = (entry: A) =>
+    new ParameterBinderWithValue() {
+      override def value: A = entry
+      override def apply(stmt: PreparedStatement, idx: Int): Unit = {
+        stmt.setInt(idx, value.value)
+      }
+    }
+}

--- a/enumeratum-scalikejdbc/src/main/scala/enumeratum/values/LongScalikeJDBCEnum.scala
+++ b/enumeratum-scalikejdbc/src/main/scala/enumeratum/values/LongScalikeJDBCEnum.scala
@@ -1,0 +1,23 @@
+package enumeratum.values
+
+import scalikejdbc.{ParameterBinderFactory, ParameterBinderWithValue, TypeBinder}
+
+import java.sql.PreparedStatement
+
+trait LongScalikeJDBCEnum[A <: LongEnumEntry] extends LongEnum[A] {
+  implicit val typeBinder: TypeBinder[A] = {
+    TypeBinder.long.map(withValue)
+  }
+
+  implicit val optionalTypeBinder: TypeBinder[Option[A]] = {
+    TypeBinder.long.map(withValueOpt)
+  }
+
+  implicit val parameterBinderFactory: ParameterBinderFactory[A] = (entry: A) =>
+    new ParameterBinderWithValue() {
+      override def value: A = entry
+      override def apply(stmt: PreparedStatement, idx: Int): Unit = {
+        stmt.setLong(idx, value.value)
+      }
+    }
+}

--- a/enumeratum-scalikejdbc/src/main/scala/enumeratum/values/ShortScalikeJDBCEnum.scala
+++ b/enumeratum-scalikejdbc/src/main/scala/enumeratum/values/ShortScalikeJDBCEnum.scala
@@ -1,0 +1,23 @@
+package enumeratum.values
+
+import scalikejdbc.{ParameterBinderFactory, ParameterBinderWithValue, TypeBinder}
+
+import java.sql.PreparedStatement
+
+trait ShortScalikeJDBCEnum[A <: ShortEnumEntry] extends ShortEnum[A] {
+  implicit val typeBinder: TypeBinder[A] = {
+    TypeBinder.short.map(withValue)
+  }
+
+  implicit val optionalTypeBinder: TypeBinder[Option[A]] = {
+    TypeBinder.short.map(withValueOpt)
+  }
+
+  implicit val parameterBinderFactory: ParameterBinderFactory[A] = (entry: A) =>
+    new ParameterBinderWithValue() {
+      override def value: A = entry
+      override def apply(stmt: PreparedStatement, idx: Int): Unit = {
+        stmt.setShort(idx, value.value)
+      }
+    }
+}

--- a/enumeratum-scalikejdbc/src/main/scala/enumeratum/values/StringScalikeJDBCEnum.scala
+++ b/enumeratum-scalikejdbc/src/main/scala/enumeratum/values/StringScalikeJDBCEnum.scala
@@ -1,0 +1,23 @@
+package enumeratum.values
+
+import scalikejdbc.{ParameterBinderFactory, ParameterBinderWithValue, TypeBinder}
+
+import java.sql.PreparedStatement
+
+trait StringScalikeJDBCEnum[A <: StringEnumEntry] extends StringEnum[A] {
+  implicit val typeBinder: TypeBinder[A] = {
+    TypeBinder.string.map(withValue)
+  }
+
+  implicit val optionalTypeBinder: TypeBinder[Option[A]] = {
+    TypeBinder.string.map(withValueOpt)
+  }
+
+  implicit val parameterBinderFactory: ParameterBinderFactory[A] = (entry: A) =>
+    new ParameterBinderWithValue() {
+      override def value: A = entry
+      override def apply(stmt: PreparedStatement, idx: Int): Unit = {
+        stmt.setString(idx, value.value)
+      }
+    }
+}

--- a/enumeratum-scalikejdbc/src/test/scala/enumeratum/ScalikeJDBCEnumSpec.scala
+++ b/enumeratum-scalikejdbc/src/test/scala/enumeratum/ScalikeJDBCEnumSpec.scala
@@ -1,0 +1,108 @@
+package enumeratum
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.FixtureAnyFunSpec
+import org.scalatest.matchers.should.Matchers._
+import scalikejdbc._
+import scalikejdbc.scalatest.AutoRollback
+
+import scala.collection.immutable
+
+class ScalikeJDBCEnumSpec extends FixtureAnyFunSpec with AutoRollback with BeforeAndAfterAll {
+
+  sealed trait TrafficLight extends EnumEntry
+  object TrafficLight extends ScalikeJDBCEnum[TrafficLight] {
+    case object Red    extends TrafficLight
+    case object Yellow extends TrafficLight
+    case object Green  extends TrafficLight
+    override val values: immutable.IndexedSeq[TrafficLight] = findValues
+  }
+
+  case class TrafficLightRow(id: Int, trafficLight: TrafficLight)
+  object TrafficLightRow extends SQLSyntaxSupport[TrafficLightRow] {
+    override val tableName = "traffic_table"
+    def apply(rs: WrappedResultSet) = new TrafficLightRow(
+      rs.int("id"),
+      rs.get("traffic_light")
+    )
+  }
+
+  override def beforeAll(): Unit = {
+    Class.forName("org.h2.Driver")
+    ConnectionPool.singleton("jdbc:h2:mem:scalikejdbcenumspec", "user", "pass")
+
+    implicit val session: DBSession = AutoSession
+    sql"""
+    create table traffic_table (
+      id integer not null primary key,
+      traffic_light enum('Red', 'Yellow', 'Green')
+    )
+    """.execute.apply() shouldBe false
+  }
+
+  override def fixture(implicit session: DBSession): Unit = {
+    sql"insert into traffic_table values (1, ${"Red"})".update.apply() shouldBe 1
+    sql"insert into traffic_table values (2, ${"Green"})".update.apply() shouldBe 1
+  }
+
+  describe("select") {
+    it("use SQLInterpolation") { implicit dbSession =>
+      // exercise
+      val Some(trafficLightRow: TrafficLightRow) = sql"select * from traffic_table where id = 1"
+        .map(TrafficLightRow.apply)
+        .single
+        .apply()
+
+      // verify
+      trafficLightRow.id shouldBe 1
+      trafficLightRow.trafficLight shouldBe TrafficLight.Red
+    }
+
+    it("use QueryDSL") { implicit dbSession =>
+      // exercise
+      val t = TrafficLightRow.syntax("t")
+      val Some(trafficLightRow: TrafficLightRow) = withSQL {
+        select.from(TrafficLightRow as t).where.eq(t.id, 1)
+      }.map(TrafficLightRow.apply).single.apply()
+
+      // verify
+      trafficLightRow.id shouldBe 1
+      trafficLightRow.trafficLight shouldBe TrafficLight.Red
+    }
+  }
+
+  describe("insert") {
+    it("use SQLInterpolation") { implicit dbSession =>
+      // exercise
+      sql"insert into traffic_table (id, traffic_light) values (3, ${"Green"})".update
+        .apply() shouldBe 1
+
+      // verify
+      val Some(trafficLightRow: TrafficLightRow) = sql"select * from traffic_table where id = 3"
+        .map(TrafficLightRow.apply)
+        .single
+        .apply()
+      trafficLightRow.trafficLight shouldBe TrafficLight.Green
+    }
+
+    it("use QueryDSL") { implicit dbSession =>
+      // exercise
+      val c = TrafficLightRow.column
+      applyUpdate {
+        insert
+          .into(TrafficLightRow)
+          .namedValues(
+            c.id           -> 3,
+            c.trafficLight -> (TrafficLight.Green: TrafficLight)
+          )
+      } shouldBe 1
+
+      // verify
+      val t = TrafficLightRow.syntax("t")
+      val Some(trafficLightRow: TrafficLightRow) = withSQL {
+        select.from(TrafficLightRow as t).where.eq(t.id, 3)
+      }.map(TrafficLightRow.apply).single.apply()
+      trafficLightRow.trafficLight shouldBe TrafficLight.Green
+    }
+  }
+}

--- a/enumeratum-scalikejdbc/src/test/scala/enumeratum/values/ByteScalikeJDBCEnumSpec.scala
+++ b/enumeratum-scalikejdbc/src/test/scala/enumeratum/values/ByteScalikeJDBCEnumSpec.scala
@@ -1,0 +1,113 @@
+package enumeratum.values
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.FixtureAnyFunSpec
+import org.scalatest.matchers.should.Matchers._
+import scalikejdbc._
+import scalikejdbc.scalatest.AutoRollback
+
+import scala.collection.immutable
+
+class ByteScalikeJDBCEnumSpec extends FixtureAnyFunSpec with AutoRollback with BeforeAndAfterAll {
+
+  sealed abstract class TrafficLight(override val value: Byte) extends ByteEnumEntry
+  object TrafficLight extends ByteScalikeJDBCEnum[TrafficLight] {
+    case object Red    extends TrafficLight(1)
+    case object Yellow extends TrafficLight(2)
+    case object Green  extends TrafficLight(3)
+    override val values: immutable.IndexedSeq[TrafficLight] = findValues
+  }
+
+  case class TrafficLightRow(id: Int, trafficLight: TrafficLight)
+  object TrafficLightRow extends SQLSyntaxSupport[TrafficLightRow] {
+    override val tableName: String    = "traffic_table"
+    override val columns: Seq[String] = Seq("id", "traffic_light_value")
+
+    def apply(rs: WrappedResultSet) = new TrafficLightRow(
+      rs.int("id"),
+      rs.get("traffic_light_value")
+    )
+
+    override val nameConverters: Map[String, String] =
+      Map("^trafficLight$" -> "traffic_light_value")
+  }
+
+  override def beforeAll(): Unit = {
+    Class.forName("org.h2.Driver")
+    ConnectionPool.singleton("jdbc:h2:mem:bytescalikejdbcenumspec", "user", "pass")
+
+    implicit val session: DBSession = AutoSession
+    sql"""
+    create table traffic_table (
+      id integer not null primary key,
+      traffic_light_value tinyint
+    )
+    """.execute.apply() shouldBe false
+  }
+
+  override def fixture(implicit session: DBSession): Unit = {
+    sql"insert into traffic_table values (1, ${1})".update.apply() shouldBe 1
+    sql"insert into traffic_table values (2, ${3})".update.apply() shouldBe 1
+  }
+
+  describe("select") {
+    it("use SQLInterpolation") { implicit dbSession =>
+      // exercise
+      val Some(trafficLightRow: TrafficLightRow) = sql"select * from traffic_table where id = 1"
+        .map(TrafficLightRow.apply)
+        .single
+        .apply()
+
+      // verify
+      trafficLightRow.id shouldBe 1
+      trafficLightRow.trafficLight shouldBe TrafficLight.Red
+    }
+
+    it("use QueryDSL") { implicit dbSession =>
+      // exercise
+      val t = TrafficLightRow.syntax("t")
+      val Some(trafficLightRow: TrafficLightRow) = withSQL {
+        select.from(TrafficLightRow as t).where.eq(t.id, 1)
+      }.map(TrafficLightRow.apply).single.apply()
+
+      // verify
+      trafficLightRow.id shouldBe 1
+      trafficLightRow.trafficLight shouldBe TrafficLight.Red
+    }
+  }
+
+  describe("insert") {
+    it("use SQLInterpolation") { implicit dbSession =>
+      // exercise
+      sql"insert into traffic_table (id, traffic_light_value) values (3, ${3})".update
+        .apply() shouldBe 1
+
+      // verify
+      val Some(trafficLightRow: TrafficLightRow) = sql"select * from traffic_table where id = 3"
+        .map(TrafficLightRow.apply)
+        .single
+        .apply()
+      trafficLightRow.trafficLight shouldBe TrafficLight.Green
+    }
+
+    it("use QueryDSL") { implicit dbSession =>
+      // exercise
+      val c = TrafficLightRow.column
+      applyUpdate {
+        insert
+          .into(TrafficLightRow)
+          .namedValues(
+            c.id           -> 3,
+            c.trafficLight -> (TrafficLight.Green: TrafficLight)
+          )
+      } shouldBe 1
+
+      // verify
+      val t = TrafficLightRow.syntax("t")
+      val Some(trafficLightRow: TrafficLightRow) = withSQL {
+        select.from(TrafficLightRow as t).where.eq(t.id, 3)
+      }.map(TrafficLightRow.apply).single.apply()
+      trafficLightRow.trafficLight shouldBe TrafficLight.Green
+    }
+  }
+}

--- a/enumeratum-scalikejdbc/src/test/scala/enumeratum/values/CharScalikeJDBCEnumSpec.scala
+++ b/enumeratum-scalikejdbc/src/test/scala/enumeratum/values/CharScalikeJDBCEnumSpec.scala
@@ -1,0 +1,113 @@
+package enumeratum.values
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.FixtureAnyFunSpec
+import org.scalatest.matchers.should.Matchers._
+import scalikejdbc._
+import scalikejdbc.scalatest.AutoRollback
+
+import scala.collection.immutable
+
+class CharScalikeJDBCEnumSpec extends FixtureAnyFunSpec with AutoRollback with BeforeAndAfterAll {
+
+  sealed abstract class TrafficLight(override val value: Char) extends CharEnumEntry
+  object TrafficLight extends CharScalikeJDBCEnum[TrafficLight] {
+    case object Red    extends TrafficLight('r')
+    case object Yellow extends TrafficLight('y')
+    case object Green  extends TrafficLight('g')
+    override val values: immutable.IndexedSeq[TrafficLight] = findValues
+  }
+
+  case class TrafficLightRow(id: Int, trafficLight: TrafficLight)
+  object TrafficLightRow extends SQLSyntaxSupport[TrafficLightRow] {
+    override val tableName: String    = "traffic_table"
+    override val columns: Seq[String] = Seq("id", "traffic_light_value")
+
+    def apply(rs: WrappedResultSet) = new TrafficLightRow(
+      rs.int("id"),
+      rs.get("traffic_light_value")
+    )
+
+    override val nameConverters: Map[String, String] =
+      Map("^trafficLight$" -> "traffic_light_value")
+  }
+
+  override def beforeAll(): Unit = {
+    Class.forName("org.h2.Driver")
+    ConnectionPool.singleton("jdbc:h2:mem:charscalikejdbcenumspec", "user", "pass")
+
+    implicit val session: DBSession = AutoSession
+    sql"""
+    create table traffic_table (
+      id integer not null primary key,
+      traffic_light_value character
+    )
+    """.execute.apply() shouldBe false
+  }
+
+  override def fixture(implicit session: DBSession): Unit = {
+    sql"insert into traffic_table values (1, ${'r'})".update.apply() shouldBe 1
+    sql"insert into traffic_table values (2, ${'g'})".update.apply() shouldBe 1
+  }
+
+  describe("select") {
+    it("use SQLInterpolation") { implicit dbSession =>
+      // exercise
+      val Some(trafficLightRow: TrafficLightRow) = sql"select * from traffic_table where id = 1"
+        .map(TrafficLightRow.apply)
+        .single
+        .apply()
+
+      // verify
+      trafficLightRow.id shouldBe 1
+      trafficLightRow.trafficLight shouldBe TrafficLight.Red
+    }
+
+    it("use QueryDSL") { implicit dbSession =>
+      // exercise
+      val t = TrafficLightRow.syntax("t")
+      val Some(trafficLightRow: TrafficLightRow) = withSQL {
+        select.from(TrafficLightRow as t).where.eq(t.id, 1)
+      }.map(TrafficLightRow.apply).single.apply()
+
+      // verify
+      trafficLightRow.id shouldBe 1
+      trafficLightRow.trafficLight shouldBe TrafficLight.Red
+    }
+  }
+
+  describe("insert") {
+    it("use SQLInterpolation") { implicit dbSession =>
+      // exercise
+      sql"insert into traffic_table (id, traffic_light_value) values (3, ${'g'})".update
+        .apply() shouldBe 1
+
+      // verify
+      val Some(trafficLightRow: TrafficLightRow) = sql"select * from traffic_table where id = 3"
+        .map(TrafficLightRow.apply)
+        .single
+        .apply()
+      trafficLightRow.trafficLight shouldBe TrafficLight.Green
+    }
+
+    it("use QueryDSL") { implicit dbSession =>
+      // exercise
+      val c = TrafficLightRow.column
+      applyUpdate {
+        insert
+          .into(TrafficLightRow)
+          .namedValues(
+            c.id           -> 3,
+            c.trafficLight -> (TrafficLight.Green: TrafficLight)
+          )
+      } shouldBe 1
+
+      // verify
+      val t = TrafficLightRow.syntax("t")
+      val Some(trafficLightRow: TrafficLightRow) = withSQL {
+        select.from(TrafficLightRow as t).where.eq(t.id, 3)
+      }.map(TrafficLightRow.apply).single.apply()
+      trafficLightRow.trafficLight shouldBe TrafficLight.Green
+    }
+  }
+}

--- a/enumeratum-scalikejdbc/src/test/scala/enumeratum/values/IntScalikeJDBCEnumSpec.scala
+++ b/enumeratum-scalikejdbc/src/test/scala/enumeratum/values/IntScalikeJDBCEnumSpec.scala
@@ -1,0 +1,113 @@
+package enumeratum.values
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.FixtureAnyFunSpec
+import org.scalatest.matchers.should.Matchers._
+import scalikejdbc._
+import scalikejdbc.scalatest.AutoRollback
+
+import scala.collection.immutable
+
+class IntScalikeJDBCEnumSpec extends FixtureAnyFunSpec with AutoRollback with BeforeAndAfterAll {
+
+  sealed abstract class TrafficLight(override val value: Int) extends IntEnumEntry
+  object TrafficLight extends IntScalikeJDBCEnum[TrafficLight] {
+    case object Red    extends TrafficLight(1)
+    case object Yellow extends TrafficLight(2)
+    case object Green  extends TrafficLight(3)
+    override val values: immutable.IndexedSeq[TrafficLight] = findValues
+  }
+
+  case class TrafficLightRow(id: Int, trafficLight: TrafficLight)
+  object TrafficLightRow extends SQLSyntaxSupport[TrafficLightRow] {
+    override val tableName: String    = "traffic_table"
+    override val columns: Seq[String] = Seq("id", "traffic_light_value")
+
+    def apply(rs: WrappedResultSet) = new TrafficLightRow(
+      rs.int("id"),
+      rs.get("traffic_light_value")
+    )
+
+    override val nameConverters: Map[String, String] =
+      Map("^trafficLight$" -> "traffic_light_value")
+  }
+
+  override def beforeAll(): Unit = {
+    Class.forName("org.h2.Driver")
+    ConnectionPool.singleton("jdbc:h2:mem:intscalikejdbcenumspec", "user", "pass")
+
+    implicit val session: DBSession = AutoSession
+    sql"""
+    create table traffic_table (
+      id integer not null primary key,
+      traffic_light_value integer
+    )
+    """.execute.apply() shouldBe false
+  }
+
+  override def fixture(implicit session: DBSession): Unit = {
+    sql"insert into traffic_table values (1, ${1})".update.apply() shouldBe 1
+    sql"insert into traffic_table values (2, ${3})".update.apply() shouldBe 1
+  }
+
+  describe("select") {
+    it("use SQLInterpolation") { implicit dbSession =>
+      // exercise
+      val Some(trafficLightRow: TrafficLightRow) = sql"select * from traffic_table where id = 1"
+        .map(TrafficLightRow.apply)
+        .single
+        .apply()
+
+      // verify
+      trafficLightRow.id shouldBe 1
+      trafficLightRow.trafficLight shouldBe TrafficLight.Red
+    }
+
+    it("use QueryDSL") { implicit dbSession =>
+      // exercise
+      val t = TrafficLightRow.syntax("t")
+      val Some(trafficLightRow: TrafficLightRow) = withSQL {
+        select.from(TrafficLightRow as t).where.eq(t.id, 1)
+      }.map(TrafficLightRow.apply).single.apply()
+
+      // verify
+      trafficLightRow.id shouldBe 1
+      trafficLightRow.trafficLight shouldBe TrafficLight.Red
+    }
+  }
+
+  describe("insert") {
+    it("use SQLInterpolation") { implicit dbSession =>
+      // exercise
+      sql"insert into traffic_table (id, traffic_light_value) values (3, ${3})".update
+        .apply() shouldBe 1
+
+      // verify
+      val Some(trafficLightRow: TrafficLightRow) = sql"select * from traffic_table where id = 3"
+        .map(TrafficLightRow.apply)
+        .single
+        .apply()
+      trafficLightRow.trafficLight shouldBe TrafficLight.Green
+    }
+
+    it("use QueryDSL") { implicit dbSession =>
+      // exercise
+      val c = TrafficLightRow.column
+      applyUpdate {
+        insert
+          .into(TrafficLightRow)
+          .namedValues(
+            c.id           -> 3,
+            c.trafficLight -> (TrafficLight.Green: TrafficLight)
+          )
+      } shouldBe 1
+
+      // verify
+      val t = TrafficLightRow.syntax("t")
+      val Some(trafficLightRow: TrafficLightRow) = withSQL {
+        select.from(TrafficLightRow as t).where.eq(t.id, 3)
+      }.map(TrafficLightRow.apply).single.apply()
+      trafficLightRow.trafficLight shouldBe TrafficLight.Green
+    }
+  }
+}

--- a/enumeratum-scalikejdbc/src/test/scala/enumeratum/values/LongScalikeJDBCEnumSpec.scala
+++ b/enumeratum-scalikejdbc/src/test/scala/enumeratum/values/LongScalikeJDBCEnumSpec.scala
@@ -1,0 +1,113 @@
+package enumeratum.values
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.FixtureAnyFunSpec
+import org.scalatest.matchers.should.Matchers._
+import scalikejdbc._
+import scalikejdbc.scalatest.AutoRollback
+
+import scala.collection.immutable
+
+class LongScalikeJDBCEnumSpec extends FixtureAnyFunSpec with AutoRollback with BeforeAndAfterAll {
+
+  sealed abstract class TrafficLight(override val value: Long) extends LongEnumEntry
+  object TrafficLight extends LongScalikeJDBCEnum[TrafficLight] {
+    case object Red    extends TrafficLight(1L)
+    case object Yellow extends TrafficLight(2L)
+    case object Green  extends TrafficLight(3L)
+    override val values: immutable.IndexedSeq[TrafficLight] = findValues
+  }
+
+  case class TrafficLightRow(id: Int, trafficLight: TrafficLight)
+  object TrafficLightRow extends SQLSyntaxSupport[TrafficLightRow] {
+    override val tableName: String    = "traffic_table"
+    override val columns: Seq[String] = Seq("id", "traffic_light_value")
+
+    def apply(rs: WrappedResultSet) = new TrafficLightRow(
+      rs.int("id"),
+      rs.get("traffic_light_value")
+    )
+
+    override val nameConverters: Map[String, String] =
+      Map("^trafficLight$" -> "traffic_light_value")
+  }
+
+  override def beforeAll(): Unit = {
+    Class.forName("org.h2.Driver")
+    ConnectionPool.singleton("jdbc:h2:mem:longscalikejdbcenumspec", "user", "pass")
+
+    implicit val session: DBSession = AutoSession
+    sql"""
+    create table traffic_table (
+      id integer not null primary key,
+      traffic_light_value bigint
+    )
+    """.execute.apply() shouldBe false
+  }
+
+  override def fixture(implicit session: DBSession): Unit = {
+    sql"insert into traffic_table values (1, ${1L})".update.apply() shouldBe 1
+    sql"insert into traffic_table values (2, ${3L})".update.apply() shouldBe 1
+  }
+
+  describe("select") {
+    it("use SQLInterpolation") { implicit dbSession =>
+      // exercise
+      val Some(trafficLightRow: TrafficLightRow) = sql"select * from traffic_table where id = 1"
+        .map(TrafficLightRow.apply)
+        .single
+        .apply()
+
+      // verify
+      trafficLightRow.id shouldBe 1
+      trafficLightRow.trafficLight shouldBe TrafficLight.Red
+    }
+
+    it("use QueryDSL") { implicit dbSession =>
+      // exercise
+      val t = TrafficLightRow.syntax("t")
+      val Some(trafficLightRow: TrafficLightRow) = withSQL {
+        select.from(TrafficLightRow as t).where.eq(t.id, 1)
+      }.map(TrafficLightRow.apply).single.apply()
+
+      // verify
+      trafficLightRow.id shouldBe 1
+      trafficLightRow.trafficLight shouldBe TrafficLight.Red
+    }
+  }
+
+  describe("insert") {
+    it("use SQLInterpolation") { implicit dbSession =>
+      // exercise
+      sql"insert into traffic_table (id, traffic_light_value) values (3, ${3L})".update
+        .apply() shouldBe 1
+
+      // verify
+      val Some(trafficLightRow: TrafficLightRow) = sql"select * from traffic_table where id = 3"
+        .map(TrafficLightRow.apply)
+        .single
+        .apply()
+      trafficLightRow.trafficLight shouldBe TrafficLight.Green
+    }
+
+    it("use QueryDSL") { implicit dbSession =>
+      // exercise
+      val c = TrafficLightRow.column
+      applyUpdate {
+        insert
+          .into(TrafficLightRow)
+          .namedValues(
+            c.id           -> 3,
+            c.trafficLight -> (TrafficLight.Green: TrafficLight)
+          )
+      } shouldBe 1
+
+      // verify
+      val t = TrafficLightRow.syntax("t")
+      val Some(trafficLightRow: TrafficLightRow) = withSQL {
+        select.from(TrafficLightRow as t).where.eq(t.id, 3)
+      }.map(TrafficLightRow.apply).single.apply()
+      trafficLightRow.trafficLight shouldBe TrafficLight.Green
+    }
+  }
+}

--- a/enumeratum-scalikejdbc/src/test/scala/enumeratum/values/ShortScalikeJDBCEnumSpec.scala
+++ b/enumeratum-scalikejdbc/src/test/scala/enumeratum/values/ShortScalikeJDBCEnumSpec.scala
@@ -1,0 +1,113 @@
+package enumeratum.values
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.FixtureAnyFunSpec
+import org.scalatest.matchers.should.Matchers._
+import scalikejdbc._
+import scalikejdbc.scalatest.AutoRollback
+
+import scala.collection.immutable
+
+class ShortScalikeJDBCEnumSpec extends FixtureAnyFunSpec with AutoRollback with BeforeAndAfterAll {
+
+  sealed abstract class TrafficLight(override val value: Short) extends ShortEnumEntry
+  object TrafficLight extends ShortScalikeJDBCEnum[TrafficLight] {
+    case object Red    extends TrafficLight(1)
+    case object Yellow extends TrafficLight(2)
+    case object Green  extends TrafficLight(3)
+    override val values: immutable.IndexedSeq[TrafficLight] = findValues
+  }
+
+  case class TrafficLightRow(id: Int, trafficLight: TrafficLight)
+  object TrafficLightRow extends SQLSyntaxSupport[TrafficLightRow] {
+    override val tableName: String    = "traffic_table"
+    override val columns: Seq[String] = Seq("id", "traffic_light_value")
+
+    def apply(rs: WrappedResultSet) = new TrafficLightRow(
+      rs.int("id"),
+      rs.get("traffic_light_value")
+    )
+
+    override val nameConverters: Map[String, String] =
+      Map("^trafficLight$" -> "traffic_light_value")
+  }
+
+  override def beforeAll(): Unit = {
+    Class.forName("org.h2.Driver")
+    ConnectionPool.singleton("jdbc:h2:mem:shortscalikejdbcenumspec", "user", "pass")
+
+    implicit val session: DBSession = AutoSession
+    sql"""
+    create table traffic_table (
+      id integer not null primary key,
+      traffic_light_value smallint
+    )
+    """.execute.apply() shouldBe false
+  }
+
+  override def fixture(implicit session: DBSession): Unit = {
+    sql"insert into traffic_table values (1, ${1})".update.apply() shouldBe 1
+    sql"insert into traffic_table values (2, ${3})".update.apply() shouldBe 1
+  }
+
+  describe("select") {
+    it("use SQLInterpolation") { implicit dbSession =>
+      // exercise
+      val Some(trafficLightRow: TrafficLightRow) = sql"select * from traffic_table where id = 1"
+        .map(TrafficLightRow.apply)
+        .single
+        .apply()
+
+      // verify
+      trafficLightRow.id shouldBe 1
+      trafficLightRow.trafficLight shouldBe TrafficLight.Red
+    }
+
+    it("use QueryDSL") { implicit dbSession =>
+      // exercise
+      val t = TrafficLightRow.syntax("t")
+      val Some(trafficLightRow: TrafficLightRow) = withSQL {
+        select.from(TrafficLightRow as t).where.eq(t.id, 1)
+      }.map(TrafficLightRow.apply).single.apply()
+
+      // verify
+      trafficLightRow.id shouldBe 1
+      trafficLightRow.trafficLight shouldBe TrafficLight.Red
+    }
+  }
+
+  describe("insert") {
+    it("use SQLInterpolation") { implicit dbSession =>
+      // exercise
+      sql"insert into traffic_table (id, traffic_light_value) values (3, ${3})".update
+        .apply() shouldBe 1
+
+      // verify
+      val Some(trafficLightRow: TrafficLightRow) = sql"select * from traffic_table where id = 3"
+        .map(TrafficLightRow.apply)
+        .single
+        .apply()
+      trafficLightRow.trafficLight shouldBe TrafficLight.Green
+    }
+
+    it("use QueryDSL") { implicit dbSession =>
+      // exercise
+      val c = TrafficLightRow.column
+      applyUpdate {
+        insert
+          .into(TrafficLightRow)
+          .namedValues(
+            c.id           -> 3,
+            c.trafficLight -> (TrafficLight.Green: TrafficLight)
+          )
+      } shouldBe 1
+
+      // verify
+      val t = TrafficLightRow.syntax("t")
+      val Some(trafficLightRow: TrafficLightRow) = withSQL {
+        select.from(TrafficLightRow as t).where.eq(t.id, 3)
+      }.map(TrafficLightRow.apply).single.apply()
+      trafficLightRow.trafficLight shouldBe TrafficLight.Green
+    }
+  }
+}

--- a/enumeratum-scalikejdbc/src/test/scala/enumeratum/values/StringScalikeJDBCEnumSpec.scala
+++ b/enumeratum-scalikejdbc/src/test/scala/enumeratum/values/StringScalikeJDBCEnumSpec.scala
@@ -1,0 +1,111 @@
+package enumeratum.values
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.FixtureAnyFunSpec
+import org.scalatest.matchers.should.Matchers._
+import scalikejdbc._
+import scalikejdbc.scalatest.AutoRollback
+
+import scala.collection.immutable
+
+class StringScalikeJDBCEnumSpec extends FixtureAnyFunSpec with AutoRollback with BeforeAndAfterAll {
+
+  sealed abstract class TrafficLight(override val value: String) extends StringEnumEntry
+  object TrafficLight extends StringScalikeJDBCEnum[TrafficLight] {
+    case object Red    extends TrafficLight("red")
+    case object Yellow extends TrafficLight("yellow")
+    case object Green  extends TrafficLight("green")
+    override val values: immutable.IndexedSeq[TrafficLight] = findValues
+  }
+
+  case class TrafficLightRow(id: Int, trafficLight: TrafficLight)
+  object TrafficLightRow extends SQLSyntaxSupport[TrafficLightRow] {
+    override val tableName: String    = "traffic_table"
+    override val columns: Seq[String] = Seq("id", "traffic_light_value")
+    def apply(rs: WrappedResultSet) = new TrafficLightRow(
+      rs.int("id"),
+      rs.get("traffic_light_value")
+    )
+    override val nameConverters: Map[String, String] =
+      Map("^trafficLight$" -> "traffic_light_value")
+  }
+
+  override def beforeAll(): Unit = {
+    Class.forName("org.h2.Driver")
+    ConnectionPool.singleton("jdbc:h2:mem:stringscalikejdbcenumspec", "user", "pass")
+
+    implicit val session: DBSession = AutoSession
+    sql"""
+    create table traffic_table (
+      id integer not null primary key,
+      traffic_light_value varchar(64)
+    )
+    """.execute.apply() shouldBe false
+  }
+
+  override def fixture(implicit session: DBSession): Unit = {
+    sql"insert into traffic_table values (1, ${"red"})".update.apply() shouldBe 1
+    sql"insert into traffic_table values (2, ${"green"})".update.apply() shouldBe 1
+  }
+
+  describe("select") {
+    it("use SQLInterpolation") { implicit dbSession =>
+      // exercise
+      val Some(trafficLightRow: TrafficLightRow) = sql"select * from traffic_table where id = 1"
+        .map(TrafficLightRow.apply)
+        .single
+        .apply()
+
+      // verify
+      trafficLightRow.id shouldBe 1
+      trafficLightRow.trafficLight shouldBe TrafficLight.Red
+    }
+
+    it("use QueryDSL") { implicit dbSession =>
+      // exercise
+      val t = TrafficLightRow.syntax("t")
+      val Some(trafficLightRow: TrafficLightRow) = withSQL {
+        select.from(TrafficLightRow as t).where.eq(t.id, 1)
+      }.map(TrafficLightRow.apply).single.apply()
+
+      // verify
+      trafficLightRow.id shouldBe 1
+      trafficLightRow.trafficLight shouldBe TrafficLight.Red
+    }
+  }
+
+  describe("insert") {
+    it("use SQLInterpolation") { implicit dbSession =>
+      // exercise
+      sql"insert into traffic_table (id, traffic_light_value) values (3, ${"green"})".update
+        .apply() shouldBe 1
+
+      // verify
+      val Some(trafficLightRow: TrafficLightRow) = sql"select * from traffic_table where id = 3"
+        .map(TrafficLightRow.apply)
+        .single
+        .apply()
+      trafficLightRow.trafficLight shouldBe TrafficLight.Green
+    }
+
+    it("use QueryDSL") { implicit dbSession =>
+      // exercise
+      val c = TrafficLightRow.column
+      applyUpdate {
+        insert
+          .into(TrafficLightRow)
+          .namedValues(
+            c.id           -> 3,
+            c.trafficLight -> (TrafficLight.Green: TrafficLight)
+          )
+      } shouldBe 1
+
+      // verify
+      val t = TrafficLightRow.syntax("t")
+      val Some(trafficLightRow: TrafficLightRow) = withSQL {
+        select.from(TrafficLightRow as t).where.eq(t.id, 3)
+      }.map(TrafficLightRow.apply).single.apply()
+      trafficLightRow.trafficLight shouldBe TrafficLight.Green
+    }
+  }
+}

--- a/publish-integration-libs
+++ b/publish-integration-libs
@@ -18,4 +18,6 @@ say "Done 7" &&
 sbt "project scalacheck-aggregate" +clean +publishSigned &&
 say "Done 8" &&
 sbt "project quill-aggregate" +clean +publishSigned &&
+say "Done 9" &&
+sbt "project enumeratum-scalikejdbc" +clean +publishSigned &&
 say "All done"


### PR DESCRIPTION
# summary

Add ScalikeJDBC supprt.

- add implicit TypeBinder.
- add implicit ParameterBinderFactory.
- add tests.
- add ScalikeJDBC section in README.md.
- add ScalikeJDBC project in build.sbt.
- add publish settings in publish-integration-lib.