### PR TITLE
Update slick (3.4.1)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -93,7 +93,7 @@ lazy val scala211ProjectRefs = Seq(
   // enumeratumPlay,
   enumeratumArgonautJs,
   enumeratumArgonautJvm,
-  enumeratumSlick,
+  // enumeratumSlick,
   enumeratumCirceJvm,
   enumeratumReactiveMongoBson,
   enumeratumCatsJvm,
@@ -690,9 +690,9 @@ lazy val enumeratumSlick =
     .settings(testSettings)
     .settings(
       version            := Versions.Core.head,
-      crossScalaVersions := scalaVersionsAll,
+      crossScalaVersions := scalaVersionsAll.filter(_ != scala_2_11Version),
       libraryDependencies ++= Seq(
-        ("com.typesafe.slick" %% "slick" % "3.3.3").cross(CrossVersion.for3Use2_13),
+        ("com.typesafe.slick" %% "slick" % "3.4.1").cross(CrossVersion.for3Use2_13),
         "com.h2database"       % "h2"    % "1.4.197" % Test
       ),
       libraryDependencies ++= {

--- a/enumeratum-slick/src/test/scala/enumeratum/SlickEnumSupportSpec.scala
+++ b/enumeratum-slick/src/test/scala/enumeratum/SlickEnumSupportSpec.scala
@@ -50,9 +50,9 @@ class SlickEnumSupportSpec
     }
     val lights = TableQuery[TrafficLightTable]
   }
-  class ConcreteRepository(val profile: slick.driver.H2Driver) extends TrafficLightRepository
+  class ConcreteRepository(val profile: slick.jdbc.H2Profile) extends TrafficLightRepository
 
-  val repo = new ConcreteRepository(slick.driver.H2Driver)
+  val repo = new ConcreteRepository(slick.jdbc.H2Profile)
   import repo.lights
   import repo.profile.api._
   val db = Database.forURL(


### PR DESCRIPTION
# Sumary

Update slick 3.4.1

# Background

I would like to use this library with play + slick. [The latest play-slick](https://mvnrepository.com/artifact/com.typesafe.play/play-slick_2.13/5.1.0) conforms to slick 3.4.1 and conflicts with the version of slick that enumeratum-slick depends on.

