### PR TITLE
Higher kinded type support

### DIFF
--- a/enumeratum-core/src/test/scala-2/enumeratum/values/ValueEnumSpecCompat.scala
+++ b/enumeratum-core/src/test/scala-2/enumeratum/values/ValueEnumSpecCompat.scala
@@ -1,0 +1,40 @@
+package enumeratum.values
+
+private[values] trait ValueEnumSpecCompat { this: ValueEnumSpec =>
+  // recursively referential types can't be defined inside a describe block
+  abstract class AbstractEnumEntry[A, Comp <: AbstractEnumEntryCompanion[A, ?]](
+      override val value: String
+  ) extends StringEnumEntry
+  abstract class AbstractEnumEntryCompanion[A, Entry <: AbstractEnumEntry[A, ?]](entry: Entry) {
+    def thing: A
+  }
+
+  def scalaCompat = describe("Scala2 higher-kinded types") {
+    it("should work with higher-kinded type parameters") {
+      // In scala 2, `extends StringEnum[Entry[?]]` was allowed, and worked fine with findValues.
+      // In scala 3, `extends StringEnum[Entry[?]]` is not allowed (it fails with "unreducible application of
+      // higher-kinded type Entry to wildcard arguments"). The closest thing is `extends StringEnum[Entry[Any]]`,
+      // which would not have worked with findValues in scala 2, but has been made to work in scala 3 as the
+      // existential types needed to resolve the type validly have been removed.
+      """
+      abstract class AbstractEnum[
+          Entry[A] <: AbstractEnumEntry[A, Companion[A]],
+          Companion[A] <: AbstractEnumEntryCompanion[A, Entry[A]]
+      ] extends StringEnum[Entry[?]]
+
+      sealed abstract class Enum[A](value: String) extends AbstractEnumEntry[A, EnumCompanion[A]](value)
+      sealed abstract class EnumCompanion[A](entry: Enum[A]) extends AbstractEnumEntryCompanion[A, Enum[A]](entry)
+
+      object Enum extends AbstractEnum[Enum, EnumCompanion] {
+        case class One(thing: Int) extends EnumCompanion[Int](One)
+        case object One extends Enum[Int]("One")
+
+        case class Two(thing: String) extends EnumCompanion[String](Two)
+        case object Two extends Enum[String]("Two")
+
+        override def values: IndexedSeq[Enum[?]] = findValues
+      }
+      """ should compile
+    }
+  }
+}

--- a/enumeratum-core/src/test/scala-3/enumeratum/values/ValueEnumSpecCompat.scala
+++ b/enumeratum-core/src/test/scala-3/enumeratum/values/ValueEnumSpecCompat.scala
@@ -1,0 +1,40 @@
+package enumeratum.values
+
+private[values] trait ValueEnumSpecCompat { this: ValueEnumSpec =>
+  // recursively referential types can't be defined inside a describe block
+  abstract class AbstractEnumEntry[A, Comp <: AbstractEnumEntryCompanion[A, ?]](
+      override val value: String
+  ) extends StringEnumEntry
+  abstract class AbstractEnumEntryCompanion[A, Entry <: AbstractEnumEntry[A, ?]](entry: Entry) {
+    def thing: A
+  }
+
+  def scalaCompat = describe("Scala3 higher-kinded types") {
+    it("should work with higher-kinded type parameters") {
+      // In scala 2, `extends StringEnum[Entry[?]]` was allowed, and worked fine with findValues.
+      // In scala 3, `extends StringEnum[Entry[?]]` is not allowed (it fails with "unreducible application of
+      // higher-kinded type Entry to wildcard arguments"). The closest thing is `extends StringEnum[Entry[Any]]`,
+      // which would not have worked with findValues in scala 2, but has been made to work in scala 3 as the
+      // existential types needed to resolve the type validly have been removed.
+      """
+      abstract class AbstractEnum[
+          Entry[A] <: AbstractEnumEntry[A, Companion[A]],
+          Companion[A] <: AbstractEnumEntryCompanion[A, Entry[A]]
+      ] extends StringEnum[Entry[Any]]
+
+      sealed abstract class Enum[A](value: String) extends AbstractEnumEntry[A, EnumCompanion[A]](value)
+      sealed abstract class EnumCompanion[A](entry: Enum[A]) extends AbstractEnumEntryCompanion[A, Enum[A]](entry)
+
+      object Enum extends AbstractEnum[Enum, EnumCompanion] {
+        case class One(thing: Int) extends EnumCompanion[Int](One)
+        case object One extends Enum[Int]("One")
+
+        case class Two(thing: String) extends EnumCompanion[String](Two)
+        case object Two extends Enum[String]("Two")
+
+        override def values: IndexedSeq[Enum[Any]] = findValues
+      }
+      """ should compile
+    }
+  }
+}

--- a/enumeratum-core/src/test/scala/enumeratum/values/ValueEnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/values/ValueEnumSpec.scala
@@ -135,6 +135,22 @@ class ValueEnumSpec extends AnyFunSpec with Matchers with ValueEnumHelpers {
        """ should (compile)
       }
 
+      it("should compile when there is a hierarchy of sealed traits") {
+        """
+        sealed abstract class Top(val value: Int) extends IntEnumEntry
+        sealed trait Middle extends Top
+
+        case object Top extends IntEnum[Top] {
+          case object One extends Top(1)
+          case object Two extends Top(2)
+          case object Three extends Top(3) with Middle
+          case object Four extends Top(4) with Middle
+
+          val values = findValues
+        }
+        """ should compile
+      }
+
       it("should fail to compile when there are non literal values") {
         """
         sealed abstract class ContentTypeRepeated(val value: Long, name: String) extends LongEnumEntry

--- a/enumeratum-core/src/test/scala/enumeratum/values/ValueEnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/values/ValueEnumSpec.scala
@@ -7,7 +7,11 @@ import org.scalatest.matchers.should.Matchers
   *
   * Copyright 2016
   */
-class ValueEnumSpec extends AnyFunSpec with Matchers with ValueEnumHelpers {
+class ValueEnumSpec
+    extends AnyFunSpec
+    with Matchers
+    with ValueEnumHelpers
+    with ValueEnumSpecCompat {
 
   describe("basic sanity check") {
     it("should have the proper values") {
@@ -240,4 +244,6 @@ class ValueEnumSpec extends AnyFunSpec with Matchers with ValueEnumHelpers {
       }
     }
   }
+
+  scalaCompat
 }

--- a/enumeratum-core/src/test/scala/enumeratum/values/ValueEnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/values/ValueEnumSpec.scala
@@ -152,6 +152,21 @@ class ValueEnumSpec extends AnyFunSpec with Matchers with ValueEnumHelpers {
         }
         """ shouldNot compile
       }
+
+      it("should compile when entries accept type parameters") {
+        """
+        sealed abstract class ExampleEnumEntry[Suffix](override val value: String) extends StringEnumEntry {
+          def toString(suffix: Suffix): String = value + suffix.toString
+        }
+
+        object ExampleEnum extends StringEnum[ExampleEnumEntry[?]] {
+          case object Entry1 extends ExampleEnumEntry[Int]("Entry1")
+          case object Entry2 extends ExampleEnumEntry[String]("Entry2")
+
+          override def values: IndexedSeq[ExampleEnumEntry[?]] = findValues
+        }
+        """ should compile
+      }
     }
 
     describe("trying to use with improper types") {

--- a/macros/src/main/scala-3/enumeratum/ValueEnumMacros.scala
+++ b/macros/src/main/scala-3/enumeratum/ValueEnumMacros.scala
@@ -195,8 +195,8 @@ In SBT settings:
               case ClassDef(_, _, spr, _, rhs) => {
                 val fromCtor = spr
                   .collectFirst {
-                    case Apply(Select(New(id), _), args) if id.tpe <:< repr =>
-                      args
+                    case Apply(Select(New(id), _), args) if id.tpe <:< repr               => args
+                    case Apply(TypeApply(Select(New(id), _), _), args) if id.tpe <:< repr => args
                   }
                   .flatMap(_.lift(valueParamIndex).collect { case ConstVal(const) =>
                     const


### PR DESCRIPTION
Preface: I'm not sure if this is a change you would actually want. If you don't, that's fine, we can just use our fork.
Preface 2: This needs the changes from #373 and would conflict with #371, so I based the branch off of those two. The only new changes here are the most recent commit.

Basically, in scala 2 you could have an enum that had a higher kinded type where you could have `?` as the type parameter in the `extends StringEnum[Entry[?]]`. In scala 3 this fails with `unreducible application of higher-kinded type Enum to wildcard arguments`. The simplest fix to get the type system to accept this is to replace the `?`s with `Any`s. But then `findValues` can't find the instances because they're not of the expected type. (See examples in the added tests. Note that the only difference is that two `?`s in the scala 2 test were changed to `Any`s in the scala 3 test, as it doesn't compile otherwise).

I _very slightly_ relaxed the type checking in `findValues` so that it could find instances even if they don't strictly extend the expected type because of variance. (If either type has a type parameter, the type parameters are dropped, i.e. instead of checking `Entry[String] <:< Entry[Any]` it just checks `Entry <:< Entry`). I put more details in the commit message. This relaxation also necessitated adding a cast. Since the cast is only necessary if one or both types have type parameters, and type parameters are erased at runtime, the cast itself should be safe. It could allow unsafe things to be done with the individual values, but I'd hope that anyone who has a situation complicated enough where that would be the case would understand the underlying principles well enough to be able to avoid that. (Maybe we add a flag that enables the behavior and defaults to false? I would've gone ahead and just done it, but there are a few levels of separation between the behavior itself and the `findValues` signatures so I wanted to hear thoughts first)

In the case I was looking at, the constructor was nested one layer deeper in an `Apply` call, so I also updated `collect` to use a `TreeAccumulator` to be more flexible.