### PR TITLE
🏗️ build(play-json): upgrade to Play JSON 3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -293,7 +293,7 @@ lazy val enumeratumPlayJson = crossProject(JSPlatform, JVMPlatform)
       scala_3Version
     ),
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %%% "play-json" % "2.10.1",
+      "org.playframework" %%% "play-json" % "3.0.0",
       scalaXmlTest
     ),
     libraryDependencies ++= {


### PR DESCRIPTION
Bump play-json dependency in enumeratum-play-json module to 3.0.

Play-JSON 3.0 is strictly the same in terms of code compared to 2.10.1 (see the diff: https://github.com/playframework/play-json/compare/2.10.1...3.0.0). The major change is due to the groupId renaming from `com.typesafe.play` to `org.playframework`.

-----

Note that I didn't work on upgrading to Play 3.0 in enumeratum-play for now as there's a bit more work but I'd happy to give it a try in the coming days.

I'm not entirely sure how to go about it though, as this _may_ force downstream users to upgrade (mainly because of the underlying change from Akka to Pekko in Play). I would need to check if enumeratum can be compatible with both Play 2 and Play 3.

I guess I'll provide another PR and then we can discuss and maybe test compatibility on real projects (I have some at my company that can be good candidates).