### PR TITLE
Update to the latest slick version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -585,7 +585,7 @@ lazy val enumeratumSlick =
       version            := "1.7.6-SNAPSHOT",
       crossScalaVersions := scalaVersionsAll,
       libraryDependencies ++= Seq(
-        ("com.typesafe.slick" %% "slick" % "3.5.0"),
+        ("com.typesafe.slick" %% "slick" % "3.5.1"),
         "com.h2database"       % "h2"    % "1.4.197" % Test
       ),
       libraryDependencies += scalaXmlTest,


### PR DESCRIPTION
Wondering if we could cut a release to get the dependencies up?

```
[error]         * com.typesafe.slick:slick_2.13:3.5.1 (pvp) is selected over {3.5.0, 3.4.1}
[error]             +- com.byteslounge:slick-repo_2.13:1.8.1              (depends on 3.5.1)
[error]             +- com.typesafe.slick:slick-hikaricp_2.13:3.5.1       (depends on 3.5.1)
[error]             +- com.beachape:enumeratum-slick_2.13:1.7.5           (depends on 3.5.0)
```