### PR TITLE
draft: don't check for the correct param type for empty tree

### DIFF
--- a/enumeratum-core/src/test/scala/enumeratum/values/ValueEnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/values/ValueEnumSpec.scala
@@ -118,6 +118,17 @@ class ValueEnumSpec extends AnyFunSpec with Matchers with ValueEnumHelpers {
        """ shouldNot compile
       }
 
+      it("should compile when the value constructor parameter is not first") {
+        """
+        sealed abstract class MyStatus(final val idx: Int, final val value: String) extends StringEnumEntry
+
+        object MyStatus extends StringEnum[MyStatus] {
+          case object PENDING extends MyStatus(1, "PENDING")
+          val values = findValues
+        }
+        """ should compile
+      }
+
       it("should compile even when values are repeated if AllowAlias is extended") {
         """
         sealed abstract class ContentTypeRepeated(val value: Long, name: String) extends LongEnumEntry with AllowAlias

--- a/macros/src/main/scala-3/enumeratum/ValueEnumMacros.scala
+++ b/macros/src/main/scala-3/enumeratum/ValueEnumMacros.scala
@@ -140,26 +140,8 @@ In SBT settings:
 
     val ctorParams = tpeSym.primaryConstructor.paramSymss.flatten
 
-    val enumFields = repr.typeSymbol.fieldMembers.flatMap { field =>
-      ctorParams.zipWithIndex.find { case (p, i) =>
-        p.name == field.name && (p.tree match {
-          case term: Term =>
-            term.tpe <:< valueRepr
-
-          case _ =>
-            false
-        })
-      }
-    }.toSeq
-
-    val (valueField, valueParamIndex): (Symbol, Int) = {
-      if (enumFields.size == 1) {
-        enumFields.headOption
-      } else {
-        enumFields.find(_._1.name == "value")
-      }
-    }.getOrElse {
-      Symbol.newVal(tpeSym, "value", valueRepr, Flags.Abstract, Symbol.noSymbol) -> 0
+    val (valueField, valueParamIndex): (Symbol, Int) = ctorParams.zipWithIndex.find{ case (p, _) => p.name == "value"}.getOrElse {
+      report.errorAndAbort(s"Could not find 'value' field in ${tpeSym.name}")
     }
 
     type IsValue[T <: ValueType] = T


### PR DESCRIPTION
`p.tree` ends up being the empty tree, so it makes no sense to test for it.

Can we just do this? I don't understand the code around it well enough to be sure. 