### PR TITLE
allow value constructor param to be any constructor parameter, rather than only the first

### DIFF
--- a/enumeratum-core/src/test/scala/enumeratum/values/ValueEnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/values/ValueEnumSpec.scala
@@ -118,6 +118,17 @@ class ValueEnumSpec extends AnyFunSpec with Matchers with ValueEnumHelpers {
        """ shouldNot compile
       }
 
+      it("should compile when the value constructor parameter is not first") {
+        """
+        sealed abstract class MyStatus(final val idx: Int, final val value: String) extends StringEnumEntry
+
+        object MyStatus extends StringEnum[MyStatus] {
+          case object PENDING extends MyStatus(1, "PENDING")
+          val values = findValues
+        }
+        """ should compile
+      }
+
       it("should compile even when values are repeated if AllowAlias is extended") {
         """
         sealed abstract class ContentTypeRepeated(val value: Long, name: String) extends LongEnumEntry with AllowAlias

--- a/macros/src/main/scala-3/enumeratum/ValueEnumMacros.scala
+++ b/macros/src/main/scala-3/enumeratum/ValueEnumMacros.scala
@@ -171,14 +171,14 @@ In SBT settings:
             vof <- Expr.summon[ValueOf[h]]
             constValue <- htpr.typeSymbol.tree match {
               case ClassDef(_, _, parents, _, statements) => {
-                val fromCtor = parents
-                  .collectFirst {
-                    case Apply(Select(New(id), _), args) if id.tpe <:< repr               => args
-                    case Apply(TypeApply(Select(New(id), _), _), args) if id.tpe <:< repr => args
-                  }
-                  .flatMap(_.lift(valueParamIndex.getOrElse(-1)).collect { case ConstVal(const) =>
-                    const
-                  })
+                val fromCtor = valueParamIndex.flatMap { ix =>
+                  parents
+                    .collectFirst {
+                      case Apply(Select(New(id), _), args) if id.tpe <:< repr               => args
+                      case Apply(TypeApply(Select(New(id), _), _), args) if id.tpe <:< repr => args
+                    }
+                    .flatMap(_.lift(ix).collect { case ConstVal(const) => const })
+                }
                 def fromBody = statements.collectFirst { case ConstVal(v) => v }
                 fromCtor.orElse(fromBody).flatMap { const => cls.unapply(const.value) }
               }

--- a/macros/src/main/scala-3/enumeratum/ValueEnumMacros.scala
+++ b/macros/src/main/scala-3/enumeratum/ValueEnumMacros.scala
@@ -140,26 +140,8 @@ In SBT settings:
 
     val ctorParams = tpeSym.primaryConstructor.paramSymss.flatten
 
-    val enumFields = repr.typeSymbol.fieldMembers.flatMap { field =>
-      ctorParams.zipWithIndex.find { case (p, i) =>
-        p.name == field.name && (p.tree match {
-          case term: Term =>
-            term.tpe <:< valueRepr
-
-          case _ =>
-            false
-        })
-      }
-    }.toSeq
-
-    val (valueField, valueParamIndex): (Symbol, Int) = {
-      if (enumFields.size == 1) {
-        enumFields.headOption
-      } else {
-        enumFields.find(_._1.name == "value")
-      }
-    }.getOrElse {
-      Symbol.newVal(tpeSym, "value", valueRepr, Flags.Abstract, Symbol.noSymbol) -> 0
+    val (valueField, valueParamIndex): (Symbol, Int) = ctorParams.zipWithIndex.find{ case (p, _) => p.name == "value"}.getOrElse {
+      report.errorAndAbort(s"Could not find 'value' field in ${tpeSym.name}")
     }
 
     type IsValue[T <: ValueType] = T

--- a/macros/src/main/scala-3/enumeratum/ValueEnumMacros.scala
+++ b/macros/src/main/scala-3/enumeratum/ValueEnumMacros.scala
@@ -133,33 +133,28 @@ In SBT settings:
 """)
     }
 
-    val repr   = TypeRepr.of[A](using tpe)
+    val repr   = TypeRepr.of[A]
     val tpeSym = repr.typeSymbol
 
     val valueRepr = TypeRepr.of[ValueType]
 
-    val ctorParams = tpeSym.primaryConstructor.paramSymss.flatten
-
-    val (valueField, valueParamIndex): (Symbol, Int) = ctorParams.zipWithIndex.find{ case (p, _) => p.name == "value"}.getOrElse {
-      report.errorAndAbort(s"Could not find 'value' field in ${tpeSym.name}")
-    }
+    val valueParamIndex = tpeSym.primaryConstructor.paramSymss
+      .filterNot(_.exists(_.isType))
+      .flatten
+      .zipWithIndex
+      .collectFirst {
+        case (p, i) if p.name == "value" => i
+      }
 
     type IsValue[T <: ValueType] = T
 
     object ConstVal {
       @annotation.tailrec
       def unapply(tree: Tree): Option[Constant] = tree match {
-        case NamedArg(nme, v) if (nme == valueField.name) =>
-          unapply(v)
-
-        case ValDef(nme, _, Some(v)) if (nme == valueField.name) =>
-          unapply(v)
-
-        case lit @ Literal(const) if (lit.tpe <:< valueRepr) =>
-          Some(const)
-
-        case _ =>
-          None
+        case NamedArg("value", v)                            => unapply(v)
+        case ValDef("value", _, Some(v))                     => unapply(v)
+        case lit @ Literal(const) if (lit.tpe <:< valueRepr) => Some(const)
+        case _                                               => None
       }
     }
 
@@ -175,24 +170,18 @@ In SBT settings:
           (for {
             vof <- Expr.summon[ValueOf[h]]
             constValue <- htpr.typeSymbol.tree match {
-              case ClassDef(_, _, spr, _, rhs) => {
-                val fromCtor = spr
+              case ClassDef(_, _, parents, _, statements) => {
+                val fromCtor = parents
                   .collectFirst {
                     case Apply(Select(New(id), _), args) if id.tpe <:< repr               => args
                     case Apply(TypeApply(Select(New(id), _), _), args) if id.tpe <:< repr => args
                   }
-                  .flatMap(_.lift(valueParamIndex).collect { case ConstVal(const) =>
+                  .flatMap(_.lift(valueParamIndex.getOrElse(-1)).collect { case ConstVal(const) =>
                     const
                   })
-
-                fromCtor
-                  .orElse(rhs.collectFirst { case ConstVal(v) => v })
-                  .flatMap { const =>
-                    cls.unapply(const.value)
-                  }
-
+                def fromBody = statements.collectFirst { case ConstVal(v) => v }
+                fromCtor.orElse(fromBody).flatMap { const => cls.unapply(const.value) }
               }
-
               case _ =>
                 Option.empty[ValueType]
             }
@@ -202,7 +191,7 @@ In SBT settings:
 
             case None =>
               report.errorAndAbort(
-                s"Fails to check value entry ${htpr.show} for enum ${repr.show}"
+                s"Failed to check value entry ${htpr.show} for enum ${repr.show}"
               )
           }
         }
@@ -212,8 +201,7 @@ In SBT settings:
             case Some(sum) =>
               sum.asTerm.tpe.asType match {
                 case '[SumOf[a, t]] => collect[Tuple.Concat[t, tail]](instances, values)
-
-                case _ => Left(s"Invalid `Mirror.SumOf[${TypeRepr.of[h].show}]")
+                case _              => Left(s"Invalid `Mirror.SumOf[${TypeRepr.of[h].show}]")
               }
 
             case None =>
@@ -230,7 +218,7 @@ In SBT settings:
               }
               .mkString(", ")
 
-            Left(s"Values for ${valueField.name} are not discriminated subtypes: ${details}")
+            Left(s"Values for the `value` field field are not discriminated subtypes: ${details}")
           } else {
             Right(Expr ofList instances.reverse)
           }

--- a/macros/src/main/scala-3/enumeratum/ValueEnumMacros.scala
+++ b/macros/src/main/scala-3/enumeratum/ValueEnumMacros.scala
@@ -171,7 +171,7 @@ In SBT settings:
             vof <- Expr.summon[ValueOf[h]]
             constValue <- htpr.typeSymbol.tree match {
               case ClassDef(_, _, parents, _, statements) => {
-                val fromCtor = valueParamIndex.flatMap { ix =>
+                val fromCtor = valueParamIndex.flatMap { (ix: Int) =>
                   parents
                     .collectFirst {
                       case Apply(Select(New(id), _), args) if id.tpe <:< repr               => args

--- a/macros/src/main/scala-3/enumeratum/ValueEnumMacros.scala
+++ b/macros/src/main/scala-3/enumeratum/ValueEnumMacros.scala
@@ -191,7 +191,7 @@ In SBT settings:
 
             case None =>
               report.errorAndAbort(
-                s"Failed to check value entry ${htpr.show} for enum ${repr.show}"
+                s"Fails to check value entry ${htpr.show} for enum ${repr.show}"
               )
           }
         }
@@ -218,7 +218,7 @@ In SBT settings:
               }
               .mkString(", ")
 
-            Left(s"Values for the `value` field field are not discriminated subtypes: ${details}")
+            Left(s"Values value are not discriminated subtypes: ${details}")
           } else {
             Right(Expr ofList instances.reverse)
           }

--- a/macros/src/test/scala/enumeratum/CompilationSpec.scala
+++ b/macros/src/test/scala/enumeratum/CompilationSpec.scala
@@ -136,3 +136,9 @@ object F {
   case object F4 extends F(value = 4, "mike")
 
 }
+
+sealed abstract class G(val name: String, val value: Int)
+object G {
+  val values = FindValEnums[G]
+  case object G1 extends G("gerald", 1)
+}


### PR DESCRIPTION
simplify and correct finding the constructor param index for the value param.

As a follow-up, I want to double-check whether we need to require -Yretain-trees.

Some of the boyscouting here is a matter of taste, if it's not to yours, I'm happy to revert.