### PR TITLE
Detailed error on Enum reads in enumeratum-play-json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ node_modules
 
 # Ignore compiled assets
 /public/assets
+.java-version

--- a/enumeratum-play-json/src/main/scala/enumeratum/EnumFormats.scala
+++ b/enumeratum-play-json/src/main/scala/enumeratum/EnumFormats.scala
@@ -146,7 +146,7 @@ object EnumFormats {
 
   private def readsAndExtracts[A <: EnumEntry](
       @deprecatedName(Symbol("enum")) e: Enum[A],
-      detailedError: Boolean = false
+      detailedError: Boolean
   )(extract: String => Option[A]): Reads[A] = Reads[A] {
     case JsString(s) =>
       extract(s) match {
@@ -166,7 +166,7 @@ object EnumFormats {
 
   private def readsKeyAndExtracts[A <: EnumEntry](
       @deprecatedName(Symbol("enum")) e: Enum[A],
-      detailedError: Boolean = false
+      detailedError: Boolean
   )(extract: String => Option[A]): KeyReads[A] = new KeyReads[A] {
     def readKey(s: String): JsResult[A] = extract(s) match {
       case Some(obj) => JsSuccess(obj)

--- a/enumeratum-play-json/src/main/scala/enumeratum/EnumFormats.scala
+++ b/enumeratum-play-json/src/main/scala/enumeratum/EnumFormats.scala
@@ -112,9 +112,10 @@ object EnumFormats {
     */
   def formats[A <: EnumEntry](
       @deprecatedName(Symbol("enum")) e: Enum[A],
-      insensitive: Boolean = false
+      insensitive: Boolean = false,
+      detailedError: Boolean = false
   ): Format[A] = {
-    Format(reads(e, insensitive), writes(e))
+    Format(reads(e, insensitive, detailedError), writes(e))
   }
 
   /** Returns a Json format for a given enum [[Enum]] for handling lower case transformations
@@ -123,9 +124,10 @@ object EnumFormats {
     *   The enum
     */
   def formatsLowerCaseOnly[A <: EnumEntry](
-      @deprecatedName(Symbol("enum")) e: Enum[A]
+      @deprecatedName(Symbol("enum")) e: Enum[A],
+      detailedError: Boolean = false
   ): Format[A] = {
-    Format(readsLowercaseOnly(e), writesLowercaseOnly(e))
+    Format(readsLowercaseOnly(e, detailedError), writesLowercaseOnly(e))
   }
 
   /** Returns a Json format for a given enum [[Enum]] for handling upper case transformations
@@ -134,9 +136,10 @@ object EnumFormats {
     *   The enum
     */
   def formatsUppercaseOnly[A <: EnumEntry](
-      @deprecatedName(Symbol("enum")) e: Enum[A]
+      @deprecatedName(Symbol("enum")) e: Enum[A],
+      detailedError: Boolean = false
   ): Format[A] = {
-    Format(readsUppercaseOnly(e), writesUppercaseOnly(e))
+    Format(readsUppercaseOnly(e, detailedError), writesUppercaseOnly(e))
   }
 
   // ---

--- a/enumeratum-play-json/src/main/scala/enumeratum/EnumFormats.scala
+++ b/enumeratum-play-json/src/main/scala/enumeratum/EnumFormats.scala
@@ -146,7 +146,13 @@ object EnumFormats {
           )
       }
 
-    case _ => JsError("error.expected.enumstring")
+    case s =>
+      JsError(
+        JsonValidationError(
+          "error.expected.enumstring",
+          s"valid enum values are: (${e.values.map(_.entryName).mkString(", ")}), but provided: $s"
+        )
+      )
   }
 
   private def readsKeyAndExtracts[A <: EnumEntry](

--- a/enumeratum-play-json/src/main/scala/enumeratum/EnumFormats.scala
+++ b/enumeratum-play-json/src/main/scala/enumeratum/EnumFormats.scala
@@ -137,7 +137,13 @@ object EnumFormats {
     case JsString(s) =>
       extract(s) match {
         case Some(obj) => JsSuccess(obj)
-        case None      => JsError("error.expected.validenumvalue")
+        case None =>
+          JsError(
+            JsonValidationError(
+              "error.expected.validenumvalue",
+              s"valid enum values are: (${e.values.map(_.entryName).mkString(", ")}), but provided: $s"
+            )
+          )
       }
 
     case _ => JsError("error.expected.enumstring")
@@ -148,7 +154,13 @@ object EnumFormats {
   )(extract: String => Option[A]): KeyReads[A] = new KeyReads[A] {
     def readKey(s: String): JsResult[A] = extract(s) match {
       case Some(obj) => JsSuccess(obj)
-      case None      => JsError("error.expected.validenumvalue")
+      case None =>
+        JsError(
+          JsonValidationError(
+            "error.expected.validenumvalue",
+            s"valid enum values are: (${e.values.map(_.entryName).mkString(", ")}), but provided: $s"
+          )
+        )
     }
   }
 }

--- a/enumeratum-play-json/src/main/scala/enumeratum/PlayDetailedErrorJsonEnum.scala
+++ b/enumeratum-play-json/src/main/scala/enumeratum/PlayDetailedErrorJsonEnum.scala
@@ -1,0 +1,20 @@
+package enumeratum
+
+import play.api.libs.json._
+
+trait PlayDetailedErrorJsonEnum[A <: EnumEntry] { self: Enum[A] =>
+  implicit val keyWrites: KeyWrites[A] = EnumFormats.keyWrites(this)
+
+  implicit def contraKeyWrites[K <: A]: KeyWrites[K] = {
+    val w = this.keyWrites
+
+    new KeyWrites[K] {
+      def writeKey(k: K) = w.writeKey(k)
+    }
+  }
+
+  implicit val keyReads: KeyReads[A] = EnumFormats.keyReads(this, detailedError = true)
+
+  implicit val jsonFormat: Format[A]               = EnumFormats.formats(this, detailedError = true)
+  implicit def contraJsonWrites[B <: A]: Writes[B] = jsonFormat.contramap[B](b => b: A)
+}

--- a/enumeratum-play-json/src/test/scala/enumeratum/Dummy.scala
+++ b/enumeratum-play-json/src/test/scala/enumeratum/Dummy.scala
@@ -37,3 +37,11 @@ object UppercaseDummy extends Enum[UppercaseDummy] with PlayUppercaseJsonEnum[Up
   case object Cherry extends UppercaseDummy
   val values = findValues
 }
+
+sealed trait Operation extends EnumEntry
+object Operation extends Enum[Operation] with PlayDetailedErrorJsonEnum[Operation] {
+  val values = findValues
+  case object Eq  extends Operation
+  case object Add extends Operation
+  case object Not extends Operation
+}

--- a/enumeratum-play-json/src/test/scala/enumeratum/EnumFormatsSpec.scala
+++ b/enumeratum-play-json/src/test/scala/enumeratum/EnumFormatsSpec.scala
@@ -87,7 +87,6 @@ class EnumFormatsSpec extends AnyFunSpec with Matchers {
     readErrors = Map(
       "A" -> ReadError(
         errorMessages = Seq("error.expected.validenumvalue"),
-        // FIXME it looks strange
         errorArgs = Seq("valid enum values are: (A, B, c), but provided: A")
       )
     ),

--- a/enumeratum-play-json/src/test/scala/enumeratum/EnumFormatsSpec.scala
+++ b/enumeratum-play-json/src/test/scala/enumeratum/EnumFormatsSpec.scala
@@ -84,6 +84,31 @@ class EnumFormatsSpec extends AnyFunSpec with Matchers {
     writeExpectations = Map(Dummy.A -> "A")
   )
 
+  testDetailedErrorScenario(
+    descriptor = "case insensitive with detailed error",
+    reads = EnumFormats.reads(e = Dummy, insensitive = true, detailedError = true),
+    readSuccessExpectations = Map(
+      "A" -> Dummy.A,
+      "a" -> Dummy.A
+    ),
+    readErrors = Map.empty,
+    writes = EnumFormats.writes(Dummy),
+    writeExpectations = Map(Dummy.A -> "A"),
+    formats = EnumFormats.formats(e = Dummy, insensitive = true, detailedError = true)
+  )
+
+  testKeyScenario(
+    descriptor = "case insensitive with detailed error",
+    reads = EnumFormats.keyReads(e = Dummy, insensitive = true, detailedError = true),
+    readSuccessExpectations = Map(
+      "A" -> Dummy.A,
+      "a" -> Dummy.A
+    ),
+    readErrors = Map.empty,
+    writes = EnumFormats.keyWrites(Dummy),
+    writeExpectations = Map(Dummy.A -> "A")
+  )
+
   testScenario(
     descriptor = "lower case transformed",
     reads = EnumFormats.readsLowercaseOnly(Dummy),
@@ -106,6 +131,39 @@ class EnumFormatsSpec extends AnyFunSpec with Matchers {
     ),
     readErrors = Map(
       "A" -> ReadError.onlyMessages(Seq("error.expected.validenumvalue"))
+    ),
+    writes = EnumFormats.keyWritesLowercaseOnly(Dummy),
+    writeExpectations = Map(Dummy.A -> "a")
+  )
+
+  testDetailedErrorScenario(
+    descriptor = "lower case transformed with detailed error",
+    reads = EnumFormats.readsLowercaseOnly(Dummy, detailedError = true),
+    readSuccessExpectations = Map(
+      "a" -> Dummy.A
+    ),
+    readErrors = Map(
+      "A" -> ReadError(
+        errorMessages = Seq("error.expected.validenumvalue"),
+        errorArgs = Seq("valid enum values are: (A, B, c), but provided: A")
+      )
+    ),
+    writes = EnumFormats.writesLowercaseOnly(Dummy),
+    writeExpectations = Map(Dummy.A -> "a"),
+    formats = EnumFormats.formatsLowerCaseOnly(Dummy, detailedError = true)
+  )
+
+  testKeyScenario(
+    descriptor = "lower case transformed with detailed error",
+    reads = EnumFormats.keyReadsLowercaseOnly(Dummy, detailedError = true),
+    readSuccessExpectations = Map(
+      "a" -> Dummy.A
+    ),
+    readErrors = Map(
+      "A" -> ReadError(
+        errorMessages = Seq("error.expected.validenumvalue"),
+        errorArgs = Seq("valid enum values are: (A, B, c), but provided: A")
+      )
     ),
     writes = EnumFormats.keyWritesLowercaseOnly(Dummy),
     writeExpectations = Map(Dummy.A -> "a")
@@ -135,6 +193,41 @@ class EnumFormatsSpec extends AnyFunSpec with Matchers {
     ),
     readErrors = Map(
       "a" -> ReadError.onlyMessages(Seq("error.expected.validenumvalue"))
+    ),
+    writes = EnumFormats.keyWritesUppercaseOnly(Dummy),
+    writeExpectations = Map(Dummy.A -> "A")
+  )
+
+  testDetailedErrorScenario(
+    descriptor = "upper case transformed with detailed error",
+    reads = EnumFormats.readsUppercaseOnly(Dummy, detailedError = true),
+    readSuccessExpectations = Map(
+      "A" -> Dummy.A,
+      "C" -> Dummy.c
+    ),
+    readErrors = Map(
+      "a" -> ReadError(
+        errorMessages = Seq("error.expected.validenumvalue"),
+        errorArgs = Seq("valid enum values are: (A, B, c), but provided: a")
+      )
+    ),
+    writes = EnumFormats.writesUppercaseOnly(Dummy),
+    writeExpectations = Map(Dummy.A -> "A"),
+    formats = EnumFormats.formatsUppercaseOnly(Dummy, detailedError = true)
+  )
+
+  testKeyScenario(
+    descriptor = "upper case transformed with detailed error",
+    reads = EnumFormats.keyReadsUppercaseOnly(Dummy, detailedError = true),
+    readSuccessExpectations = Map(
+      "A" -> Dummy.A,
+      "C" -> Dummy.c
+    ),
+    readErrors = Map(
+      "a" -> ReadError(
+        errorMessages = Seq("error.expected.validenumvalue"),
+        errorArgs = Seq("valid enum values are: (A, B, c), but provided: a")
+      )
     ),
     writes = EnumFormats.keyWritesUppercaseOnly(Dummy),
     writeExpectations = Map(Dummy.A -> "A")

--- a/enumeratum-play-json/src/test/scala/enumeratum/PlayJsonEnumSpec.scala
+++ b/enumeratum-play-json/src/test/scala/enumeratum/PlayJsonEnumSpec.scala
@@ -1,9 +1,17 @@
 package enumeratum
 
+import org.scalatest.OptionValues._
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import play.api.libs.json.{JsNumber, JsString, JsSuccess, Json => PlayJson, Writes}
-import org.scalatest.OptionValues._
+import play.api.libs.json.{
+  JsError,
+  JsNumber,
+  JsString,
+  JsSuccess,
+  JsonValidationError,
+  Writes,
+  Json => PlayJson
+}
 
 class PlayJsonEnumSpec extends AnyFunSpec with Matchers {
 
@@ -61,6 +69,22 @@ class PlayJsonEnumSpec extends AnyFunSpec with Matchers {
         PlayJson.obj("APPLE" -> 4).validate[Map[UppercaseDummy, Int]] shouldBe JsSuccess(
           Map(UppercaseDummy.Apple -> 4)
         )
+      }
+
+      describe("detailed error") {
+        it("should work with valid values") {
+          JsString("Add").asOpt[Operation].value shouldBe Operation.Add
+          JsString("Eq").asOpt[Operation].value shouldBe Operation.Eq
+        }
+
+        it("should fail with detailed error message") {
+          val jsError = JsString("Subtract").validate[Operation]
+          jsError shouldBe an[JsError]
+          jsError.asInstanceOf[JsError].errors.head._2.head shouldBe JsonValidationError(
+            List("error.expected.validenumvalue"),
+            "valid enum values are: (Eq, Add, Not), but provided: Subtract"
+          )
+        }
       }
     }
 

--- a/enumeratum-play-json/src/test/scala/enumeratum/PlayJsonEnumSpec.scala
+++ b/enumeratum-play-json/src/test/scala/enumeratum/PlayJsonEnumSpec.scala
@@ -1,19 +1,12 @@
 package enumeratum
 
+import org.scalatest.Inside
 import org.scalatest.OptionValues._
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import play.api.libs.json.{
-  JsError,
-  JsNumber,
-  JsString,
-  JsSuccess,
-  JsonValidationError,
-  Writes,
-  Json => PlayJson
-}
+import play.api.libs.json.{Json => PlayJson, _}
 
-class PlayJsonEnumSpec extends AnyFunSpec with Matchers {
+class PlayJsonEnumSpec extends AnyFunSpec with Matchers with Inside {
 
   describe("JSON serdes") {
 
@@ -80,10 +73,13 @@ class PlayJsonEnumSpec extends AnyFunSpec with Matchers {
         it("should fail with detailed error message") {
           val jsError = JsString("Subtract").validate[Operation]
           jsError shouldBe an[JsError]
-          jsError.asInstanceOf[JsError].errors.head._2.head shouldBe JsonValidationError(
-            List("error.expected.validenumvalue"),
-            "valid enum values are: (Eq, Add, Not), but provided: Subtract"
-          )
+
+          inside(jsError) { case JsError((_, jve :: Nil) :: Nil) =>
+            jve shouldBe JsonValidationError(
+              List("error.expected.validenumvalue"),
+              "valid enum values are: (Eq, Add, Not), but provided: Subtract"
+            )
+          }
         }
       }
     }

--- a/enumeratum-play-json/src/test/scala/enumeratum/ReadError.scala
+++ b/enumeratum-play-json/src/test/scala/enumeratum/ReadError.scala
@@ -1,0 +1,10 @@
+package enumeratum
+
+import scala.collection.immutable
+
+case class ReadError(errorMessages: Iterable[String], errorArgs: Iterable[String])
+
+object ReadError {
+  def onlyMessages(errorMessages: Iterable[String]): ReadError =
+    new ReadError(errorMessages, errorArgs = Iterable())
+}

--- a/enumeratum-play-json/src/test/scala/enumeratum/ReadError.scala
+++ b/enumeratum-play-json/src/test/scala/enumeratum/ReadError.scala
@@ -1,7 +1,5 @@
 package enumeratum
 
-import scala.collection.immutable
-
 case class ReadError(errorMessages: Iterable[String], errorArgs: Iterable[String])
 
 object ReadError {


### PR DESCRIPTION
The PR extends integration with play-json by providing possibility to print detailed error messages when deserialization of the enum value fails. 

More details at https://github.com/lloydmeta/enumeratum/issues/409

I implemented the logic and tests, but I am not sure what is the correct way to configure it. I did it via new trait `PlayDetailedErrorJsonEnum`, but not sure whether it is the best option since a few traits with different `reads` strategies already present (`PlayInsensitiveJsonEnum`, `PlayLowercaseJsonEnum`, `PlayUppercaseJsonEnum`) and it would look bad if I would add corresponding (`PlayDetailedErrorInsensitiveJsonEnum`, `PlayDetailedErrorLowercaseJsonEnum`, `PlayDetailedErrorUppercaseJsonEnum`). 

Will it make sense to configure it as system property? Like (`-Denumeratum.playjson.detailedError=true`)? Or some another approach?
