### PR TITLE
Allow finding values inheriting from a generic intermediary subtype

### DIFF
--- a/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
@@ -43,6 +43,23 @@ class EnumSpec extends AnyFunSpec with Matchers with EnumSpecCompat {
 
         Word.values should be(IndexedSeq(Word.Hello, Word.Hi))
       }
+
+      it("should contain instance of generic subclass") {
+        sealed trait NestedGenericEnum[T] extends EnumEntry with Serializable
+
+        object NestedGenericEnum extends Enum[NestedGenericEnum[Unit]] {
+          sealed trait Intermediary[T] extends NestedGenericEnum[T]
+
+          case object A extends Intermediary[Unit]
+          case object B extends NestedGenericEnum[Unit]
+          val values = findValues
+        }
+
+        NestedGenericEnum.values should contain theSameElementsAs Seq(
+          NestedGenericEnum.A,
+          NestedGenericEnum.B
+        )
+      }
     }
 
     describe("#withName") {

--- a/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
+++ b/enumeratum-core/src/test/scala/enumeratum/EnumSpec.scala
@@ -60,6 +60,21 @@ class EnumSpec extends AnyFunSpec with Matchers with EnumSpecCompat {
           NestedGenericEnum.B
         )
       }
+
+      it("should contain exactly one instance even if it inherits two subclasses") {
+        sealed trait MyEnum extends EnumEntry with Serializable
+        object MyEnum extends Enum[MyEnum] {
+          sealed trait Intermediary1 extends MyEnum
+          sealed trait Intermediary2 extends MyEnum
+
+          case object A extends Intermediary1 with Intermediary2
+          val values = findValues
+        }
+
+        MyEnum.values should contain theSameElementsAs Seq(
+          MyEnum.A
+        )
+      }
     }
 
     describe("#withName") {

--- a/macros/src/main/scala-3/enumeratum/EnumMacros.scala
+++ b/macros/src/main/scala-3/enumeratum/EnumMacros.scala
@@ -167,7 +167,7 @@ object EnumMacros:
 
     tpr.classSymbol
       .flatMap { cls =>
-        val types = subclasses(cls.children.map(_.tree), Nil)
+        val types = subclasses(cls.children.map(_.tree), Nil).distinct
 
         if (types.isEmpty) None else Some(types)
       }

--- a/macros/src/main/scala-3/enumeratum/EnumMacros.scala
+++ b/macros/src/main/scala-3/enumeratum/EnumMacros.scala
@@ -149,22 +149,14 @@ object EnumMacros:
 
           }
       }
-
       childTpr match {
         case Some(child) => {
+          val tpeSym = child.typeSymbol
           child.asType match {
-            case ct @ '[IsEntry[t]] => {
-              val tpeSym = child.typeSymbol
-
-              if (!isObject(tpeSym)) {
-                subclasses(tpeSym.children.map(_.tree) ::: children.tail, out)
-              } else {
-                subclasses(children.tail, child :: out)
-              }
-            }
-
+            case ct @ '[IsEntry[t]] if isObject(tpeSym) =>
+              subclasses(children.tail, child :: out)
             case _ =>
-              subclasses(children.tail, out)
+              subclasses(tpeSym.children.map(_.tree) ::: children.tail, out)
           }
         }
 


### PR DESCRIPTION
Aims to solve https://github.com/lloydmeta/enumeratum/issues/424. 

Original behavior: search among subclasses only of the enum type
New behavior: search among all subclasses, taking only those inheriting from the enum type

I’ve put `NestedGenericEnum` inside the test because I think it's more obvious/readable that way but I'm totally fine to move it into Models/scala to keep consistency.  