### PR TITLE
Added singleton Put for doobie enums

### DIFF
--- a/enumeratum-doobie/src/main/scala/enumeratum/DoobieEnum.scala
+++ b/enumeratum-doobie/src/main/scala/enumeratum/DoobieEnum.scala
@@ -27,6 +27,8 @@ import doobie.Meta
   */
 trait DoobieEnum[A <: EnumEntry] { this: Enum[A] =>
 
+  implicit def enumSingletonPut[B <: A with Singleton]: Put[B] = Put[A].contramap[B](identity)
+
   implicit lazy val enumMeta: Meta[A] = Doobie.meta(this)
 
 }

--- a/enumeratum-doobie/src/main/scala/enumeratum/values/DoobieValueEnum.scala
+++ b/enumeratum-doobie/src/main/scala/enumeratum/values/DoobieValueEnum.scala
@@ -7,6 +7,9 @@ sealed trait DoobieValueEnum[ValueType, EntryType <: ValueEnumEntry[ValueType], 
   this: ValueEnum[ValueType, EntryType] =>
 
   implicit val meta: Meta[EntryType]
+
+  implicit def enumSingletonPut[SingletonEntry <: EntryType with Singleton]: Put[SingletonEntry] =
+    Put[EntryType].contramap[SingletonEntry](identity)
 }
 
 /** DoobieEnum for IntEnumEntry

--- a/enumeratum-doobie/src/test/scala/enumeratum/DoobieEnumSpec.scala
+++ b/enumeratum-doobie/src/test/scala/enumeratum/DoobieEnumSpec.scala
@@ -20,6 +20,10 @@ class DoobieEnumSpec extends AnyFunSpec with Matchers {
       DoobieRead[DoobieShirt]
     }
 
+    it("singleton values should have a Write") {
+      DoobieWrite[DoobieShirtSize.Medium.type]
+    }
+
   }
 
 }

--- a/enumeratum-doobie/src/test/scala/enumeratum/values/DoobieValueEnumSpec.scala
+++ b/enumeratum-doobie/src/test/scala/enumeratum/values/DoobieValueEnumSpec.scala
@@ -23,6 +23,10 @@ class DoobieValueEnumSpec extends AnyFunSpec with Matchers {
       DoobieRead[DoobieBorrowerToLibraryItem]
     }
 
+    it("singleton value should have a Write") {
+      DoobieWrite[DoobieLibraryItem.Book.type]
+    }
+
   }
 
   describe("A LongDoobieEnum") {
@@ -35,6 +39,10 @@ class DoobieValueEnumSpec extends AnyFunSpec with Matchers {
       DoobieRead[DoobieContent]
     }
 
+    it("singleton value should have a Write") {
+      DoobieWrite[DoobieContentType.Text.type]
+    }
+
   }
 
   describe("A ShortDoobieEnum") {
@@ -45,6 +53,10 @@ class DoobieValueEnumSpec extends AnyFunSpec with Matchers {
 
     it("should have a Read") {
       DoobieRead[DoobieDrinkManufacturer]
+    }
+
+    it("singleton value should have a Write") {
+      DoobieWrite[DoobieDrink.OrangeJuice.type]
     }
 
   }


### PR DESCRIPTION
At $work we've have a lot of enums like 
```
sealed trait FooStatus extends EnumEntry.UpperSnakecase

object FooStatus extends enumeratum.Enum[FooStatus] with DoobieEnum[FooStatus]:
  val values = findValues

  case object Initiated        extends FooStatus
  case object Completed        extends FooStatus
```

which are used in fragments with `status = ${FooStatus.Initiated: FooStatus}`. We must manually widen the type in order for the `Write[FooStatus]` instance to be found.

This PR makes `Write`-instances available for all singleton values in an `enumeratum-doobie` Enum. We can now write
`status = ${FooStatus.Initiated}` which is a lot cleaner.